### PR TITLE
Add asynchronous report generation and PDF worker

### DIFF
--- a/api/app.py
+++ b/api/app.py
@@ -2,9 +2,11 @@ from fastapi import FastAPI
 from fastapi.responses import JSONResponse, FileResponse
 from pathlib import Path
 from .routers import charts as charts_router
+from .routers import reports as reports_router
 
 app = FastAPI(title="wh-ephemeris (dev)", version="0.1.0")
 app.include_router(charts_router.router)
+app.include_router(reports_router.router)
 
 @app.get("/__health")
 def health():

--- a/api/jobs/render_report.py
+++ b/api/jobs/render_report.py
@@ -1,14 +1,16 @@
 import time
+import api.report_queue  # noqa: F401
+
 
 def main():
-    print("[worker] starting dummy worker loop...", flush=True)
-    print("[worker] (real project: consume SQS and render PDFs)", flush=True)
+    print("[worker] starting report worker loop...", flush=True)
     try:
         while True:
             time.sleep(5)
             print("[worker] heartbeat", flush=True)
     except KeyboardInterrupt:
         print("[worker] stopping.", flush=True)
+
 
 if __name__ == "__main__":
     main()

--- a/api/report_queue.py
+++ b/api/report_queue.py
@@ -1,0 +1,43 @@
+from queue import Queue
+from threading import Thread
+from pathlib import Path
+from jinja2 import Environment, FileSystemLoader, select_autoescape
+from weasyprint import HTML
+from typing import Dict, Any
+
+from .schemas import ComputeRequest
+from .routers import charts as charts_router
+
+DEV_ASSETS_DIR = Path("/app/data/dev-assets")
+DEV_ASSETS_DIR.mkdir(parents=True, exist_ok=True)
+
+reports: Dict[str, Dict[str, Any]] = {}
+queue: Queue = Queue()
+
+def _worker_loop():
+    env = Environment(
+        loader=FileSystemLoader(Path(__file__).parent / "templates"),
+        autoescape=select_autoescape()
+    )
+    template = env.get_template("report.html")
+    while True:
+        report_id, payload = queue.get()
+        reports[report_id]["status"] = "processing"
+        try:
+            chart = charts_router.compute_chart(ComputeRequest(**payload))
+            html = template.render(chart=chart)
+            pdf_path = DEV_ASSETS_DIR / f"{report_id}.pdf"
+            HTML(string=html).write_pdf(pdf_path)
+            reports[report_id]["status"] = "done"
+            reports[report_id]["file"] = pdf_path.name
+        except Exception:
+            reports[report_id]["status"] = "error"
+        finally:
+            queue.task_done()
+
+def start_worker():
+    thread = Thread(target=_worker_loop, daemon=True)
+    thread.start()
+
+# Start worker on import for dev/testing
+start_worker()

--- a/api/routers/reports.py
+++ b/api/routers/reports.py
@@ -1,0 +1,24 @@
+from fastapi import APIRouter, HTTPException
+import uuid
+
+from ..schemas import ComputeRequest, ReportCreateResponse, ReportStatusResponse
+from ..report_queue import queue, reports
+
+router = APIRouter(prefix="/v1/reports", tags=["reports"])
+
+@router.post("", response_model=ReportCreateResponse)
+def create_report(req: ComputeRequest):
+    report_id = f"rpt_{uuid.uuid4().hex[:24]}"
+    reports[report_id] = {"status": "queued", "file": None}
+    queue.put((report_id, req.model_dump()))
+    return {"id": report_id, "status": "queued"}
+
+@router.get("/{report_id}", response_model=ReportStatusResponse)
+def get_report(report_id: str):
+    info = reports.get(report_id)
+    if not info:
+        raise HTTPException(status_code=404, detail="not found")
+    data = {"id": report_id, "status": info["status"]}
+    if info["status"] == "done" and info.get("file"):
+        data["download_url"] = f"/dev-assets/{info['file']}"
+    return data

--- a/api/schemas/__init__.py
+++ b/api/schemas/__init__.py
@@ -1,1 +1,2 @@
 from .charts import ChartInput, Place, ComputeRequest, ComputeResponse, BodyOut, MetaOut
+from .reports import ReportCreateResponse, ReportStatusResponse

--- a/api/schemas/reports.py
+++ b/api/schemas/reports.py
@@ -1,0 +1,11 @@
+from pydantic import BaseModel
+from typing import Optional
+
+class ReportCreateResponse(BaseModel):
+    id: str
+    status: str
+
+class ReportStatusResponse(BaseModel):
+    id: str
+    status: str
+    download_url: Optional[str] = None

--- a/api/templates/report.html
+++ b/api/templates/report.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Natal Chart Report</title>
+  <style>
+    body { font-family: sans-serif; }
+    h1 { font-size: 24px; }
+    ul { list-style: none; padding: 0; }
+    li { margin-bottom: 4px; }
+  </style>
+</head>
+<body>
+  <h1>Natal Chart Report</h1>
+  <p>Chart ID: {{ chart.chart_id }}</p>
+  <ul>
+  {% for b in chart.bodies %}
+    <li>{{ b.name }}: {{ b.lon }}° {{ b.sign }}</li>
+  {% endfor %}
+  </ul>
+</body>
+</html>

--- a/tests/test_reports.py
+++ b/tests/test_reports.py
@@ -1,0 +1,37 @@
+import time
+from fastapi.testclient import TestClient
+from api.app import app
+
+client = TestClient(app)
+
+sample_payload = {
+    "system": "western",
+    "date": "1990-08-18",
+    "time": "14:32:00",
+    "time_known": True,
+    "place": {"lat": 17.385, "lon": 78.4867, "tz": "Asia/Kolkata", "query": "Hyderabad, IN"},
+}
+
+def test_report_lifecycle():
+    res = client.post("/v1/reports", json=sample_payload)
+    assert res.status_code == 200, res.text
+    data = res.json()
+    rid = data["id"]
+    assert data["status"] == "queued"
+
+    # Poll until done
+    for _ in range(30):
+        res = client.get(f"/v1/reports/{rid}")
+        assert res.status_code == 200
+        info = res.json()
+        if info["status"] == "done":
+            break
+        time.sleep(0.2)
+    else:
+        raise AssertionError("report not done")
+
+    assert "download_url" in info
+    url = info["download_url"]
+    res = client.get(url)
+    assert res.status_code == 200
+    assert res.headers["content-type"] == "application/pdf"


### PR DESCRIPTION
## Summary
- add `/v1/reports` endpoints for creating and checking report jobs
- implement in-memory report queue and background worker generating PDF via WeasyPrint
- include simple Jinja2 template and expose dev asset download URL

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b44a6ed0d8832b8ddff4cdab31bbcc