### PR TITLE
Add report generation endpoints and PDF worker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ data/ephemeris/sepl_*.se1
 !data/ephemeris/README.md
 !data/ephemeris/DOWNLOAD_INSTRUCTIONS.md
 !data/ephemeris/.gitkeep
+data/dev-assets/
 
 # Environment files
 .env

--- a/api/app.py
+++ b/api/app.py
@@ -1,6 +1,7 @@
 from fastapi import FastAPI
-from fastapi.responses import JSONResponse, FileResponse
+from fastapi.responses import FileResponse, JSONResponse
 from pathlib import Path
+
 from .routers import charts as charts_router
 from .routers import reports as reports_router
 
@@ -12,8 +13,8 @@ app.include_router(reports_router.router)
 def health():
     return {"ok": True}
 
-# Dev assets static serve (for quick PDF/SVG previews saved under /app/data/dev-assets)
-DEV_ASSETS_DIR = Path("/app/data/dev-assets")
+# Dev assets static serve (for quick PDF/SVG previews saved under data/dev-assets)
+DEV_ASSETS_DIR = Path(__file__).resolve().parents[1] / "data" / "dev-assets"
 DEV_ASSETS_DIR.mkdir(parents=True, exist_ok=True)
 
 @app.get("/dev-assets/{path:path}")

--- a/api/report_queue.py
+++ b/api/report_queue.py
@@ -8,9 +8,12 @@ from typing import Dict, Any
 from .schemas import ComputeRequest
 from .routers import charts as charts_router
 
-DEV_ASSETS_DIR = Path("/app/data/dev-assets")
-DEV_ASSETS_DIR.mkdir(parents=True, exist_ok=True)
+# Where generated PDFs are stored during development
+DEV_ASSETS_ROOT = Path(__file__).resolve().parents[1] / "data" / "dev-assets"
+REPORTS_DIR = DEV_ASSETS_ROOT / "reports"
+REPORTS_DIR.mkdir(parents=True, exist_ok=True)
 
+# simple in-memory report metadata store
 reports: Dict[str, Dict[str, Any]] = {}
 queue: Queue = Queue()
 
@@ -26,7 +29,7 @@ def _worker_loop():
         try:
             chart = charts_router.compute_chart(ComputeRequest(**payload))
             html = template.render(chart=chart)
-            pdf_path = DEV_ASSETS_DIR / f"{report_id}.pdf"
+            pdf_path = REPORTS_DIR / f"{report_id}.pdf"
             HTML(string=html).write_pdf(pdf_path)
             reports[report_id]["status"] = "done"
             reports[report_id]["file"] = pdf_path.name

--- a/api/routers/reports.py
+++ b/api/routers/reports.py
@@ -1,24 +1,26 @@
 from fastapi import APIRouter, HTTPException
 import uuid
 
-from ..schemas import ComputeRequest, ReportCreateResponse, ReportStatusResponse
+from ..schemas import ReportCreateRequest, ReportStatus
 from ..report_queue import queue, reports
 
 router = APIRouter(prefix="/v1/reports", tags=["reports"])
 
-@router.post("", response_model=ReportCreateResponse)
-def create_report(req: ComputeRequest):
+
+@router.post("", response_model=ReportStatus, status_code=202)
+def create_report(req: ReportCreateRequest):
     report_id = f"rpt_{uuid.uuid4().hex[:24]}"
     reports[report_id] = {"status": "queued", "file": None}
     queue.put((report_id, req.model_dump()))
     return {"id": report_id, "status": "queued"}
 
-@router.get("/{report_id}", response_model=ReportStatusResponse)
+
+@router.get("/{report_id}", response_model=ReportStatus)
 def get_report(report_id: str):
     info = reports.get(report_id)
     if not info:
         raise HTTPException(status_code=404, detail="not found")
     data = {"id": report_id, "status": info["status"]}
     if info["status"] == "done" and info.get("file"):
-        data["download_url"] = f"/dev-assets/{info['file']}"
+        data["download_url"] = f"/dev-assets/reports/{info['file']}"
     return data

--- a/api/schemas/__init__.py
+++ b/api/schemas/__init__.py
@@ -1,2 +1,2 @@
 from .charts import ChartInput, Place, ComputeRequest, ComputeResponse, BodyOut, MetaOut
-from .reports import ReportCreateResponse, ReportStatusResponse
+from .reports import ReportCreateRequest, ReportStatus

--- a/api/schemas/reports.py
+++ b/api/schemas/reports.py
@@ -1,11 +1,16 @@
-from pydantic import BaseModel
 from typing import Optional
 
-class ReportCreateResponse(BaseModel):
-    id: str
-    status: str
+from pydantic import BaseModel
 
-class ReportStatusResponse(BaseModel):
+from .charts import ChartInput
+
+
+class ReportCreateRequest(ChartInput):
+    """Payload for requesting a new report."""
+
+
+class ReportStatus(BaseModel):
     id: str
     status: str
     download_url: Optional[str] = None
+

--- a/tests/test_reports.py
+++ b/tests/test_reports.py
@@ -1,5 +1,8 @@
 import time
+from pathlib import Path
+
 from fastapi.testclient import TestClient
+
 from api.app import app
 
 client = TestClient(app)
@@ -14,7 +17,7 @@ sample_payload = {
 
 def test_report_lifecycle():
     res = client.post("/v1/reports", json=sample_payload)
-    assert res.status_code == 200, res.text
+    assert res.status_code == 202, res.text
     data = res.json()
     rid = data["id"]
     assert data["status"] == "queued"
@@ -35,3 +38,10 @@ def test_report_lifecycle():
     res = client.get(url)
     assert res.status_code == 200
     assert res.headers["content-type"] == "application/pdf"
+
+    # Ensure file exists on disk and looks like a PDF
+    pdf_path = Path("data/dev-assets/reports") / f"{rid}.pdf"
+    assert pdf_path.exists()
+    with pdf_path.open("rb") as fh:
+        header = fh.read(4)
+    assert header == b"%PDF"


### PR DESCRIPTION
## Summary
- add `ReportCreateRequest` and `ReportStatus` models
- implement `/v1/reports` endpoints with background PDF generation
- save report PDFs under `data/dev-assets/reports`
- add tests verifying report lifecycle and PDF output

## Testing
- `make test` *(fails: docker: No such file or directory)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b4548d0e64832bb18897972d517ea8