### PR TITLE
Add forecast, compatibility, and remedies APIs with report support

### DIFF
--- a/api/app.py
+++ b/api/app.py
@@ -7,6 +7,9 @@ from .routers import dashas as dashas_router
 from .routers import transits as transits_router
 
 from .routers import reports as reports_router
+from .routers import forecasts as forecasts_router
+from .routers import compatibility as compatibility_router
+from .routers import remedies as remedies_router
 from .jobs.render_report import ensure_worker_started
 
 
@@ -18,6 +21,9 @@ app.include_router(dashas_router.router)
 app.include_router(transits_router.router)
 
 app.include_router(reports_router.router)
+app.include_router(forecasts_router.router)
+app.include_router(compatibility_router.router)
+app.include_router(remedies_router.router)
 
 
 @app.on_event("startup")

--- a/api/jobs/render_report.py
+++ b/api/jobs/render_report.py
@@ -1,105 +1,3 @@
-
-"""Background worker that renders PDF reports.
-
-This worker pulls report jobs from the in-memory queue defined in
-``api.report_queue``.  For each job it computes the chart data using the
-existing ``/v1/charts/compute`` logic, renders a PDF with Jinja2 and
-WeasyPrint, stores the result and marks the job as completed.
-
-Dev environment:  PDFs are written to
-``/app/data/dev-assets/reports/{report_id}.pdf`` so they can be served by the
-FastAPI app for inspection.
-
-Prod environment:  PDFs are uploaded to the S3 bucket specified by
-``S3_BUCKET`` (default ``wh-reports``).  A ``s3://`` URL is stored in the
-job information.
-"""
-
-from __future__ import annotations
-
-import os
-from pathlib import Path
-from queue import Empty
-from typing import Any, Dict
-
-import boto3
-from jinja2 import Environment, FileSystemLoader, select_autoescape
-from weasyprint import HTML
-
-from api.report_queue import queue, reports
-from api.schemas import ComputeRequest
-from api.routers import charts as charts_router
-
-
-# Determine environment and important paths
-APP_ENV = os.getenv("APP_ENV", "dev")
-DEV_REPORTS_DIR = Path("/app/data/dev-assets/reports")
-TEMPLATES_DIR = Path(__file__).resolve().parents[1] / "templates"
-
-# Prepare Jinja2 environment once at startup
-env = Environment(
-    loader=FileSystemLoader(TEMPLATES_DIR),
-    autoescape=select_autoescape(),
-)
-template = env.get_template("report.html")
-
-
-def _store_pdf(report_id: str, pdf_bytes: bytes) -> str:
-    """Store the PDF according to the environment.
-
-    Returns the file path or URL recorded for the report.
-    """
-
-    if APP_ENV == "prod":
-        bucket = os.getenv("S3_BUCKET", "wh-reports")
-        # Support LocalStack via either S3_ENDPOINT or AWS_ENDPOINT_URL
-        endpoint = os.getenv("S3_ENDPOINT") or os.getenv("AWS_ENDPOINT_URL")
-        s3 = boto3.client("s3", endpoint_url=endpoint) if endpoint else boto3.client("s3")
-        key = f"reports/{report_id}.pdf"
-        s3.put_object(Bucket=bucket, Key=key, Body=pdf_bytes, ContentType="application/pdf")
-        return f"s3://{bucket}/{key}"
-
-    # Dev: save under data/dev-assets/reports
-    DEV_REPORTS_DIR.mkdir(parents=True, exist_ok=True)
-    pdf_path = DEV_REPORTS_DIR / f"{report_id}.pdf"
-    pdf_path.write_bytes(pdf_bytes)
-    return f"reports/{report_id}.pdf"
-
-
-def process_job(report_id: str, payload: Dict[str, Any]) -> None:
-    """Render a single report job."""
-
-    reports[report_id]["status"] = "processing"
-    try:
-        chart = charts_router.compute_chart(ComputeRequest(**payload))
-        html = template.render(chart=chart)
-        pdf_bytes = HTML(string=html).write_pdf()
-        file_ref = _store_pdf(report_id, pdf_bytes)
-        reports[report_id]["status"] = "done"
-        reports[report_id]["file"] = file_ref
-    except Exception:
-        # In a real worker we'd log the exception details
-        reports[report_id]["status"] = "error"
-    finally:
-        queue.task_done()
-
-
-def main() -> None:
-    """Main worker loop."""
-
-    print("[worker] starting report worker loop...", flush=True)
-    try:
-        while True:
-            try:
-                report_id, payload = queue.get(timeout=5)
-            except Empty:
-                # No job - provide a heartbeat so container logs show liveness
-                print("[worker] heartbeat", flush=True)
-                continue
-            process_job(report_id, payload)
-    except KeyboardInterrupt:
-        print("[worker] stopping.", flush=True)
-
 """Background worker that renders PDF reports in-process."""
 
 import threading
@@ -112,8 +10,6 @@ from ..services.job_store import STORE
 from ..services.pdf_renderer import render_western_natal_pdf
 from ..services.wheel_svg import simple_wheel_svg
 
-
-# Reuse compute logic from charts router
 from ..routers.charts import compute_chart
 from ..schemas import ComputeRequest
 
@@ -137,11 +33,74 @@ def worker_loop() -> None:
             STORE.update(rid, status="processing")
             job = STORE.get(rid)
             payload = job["payload"]
-            data = _build_payload(payload)
+            product = payload["product"]
+            ci = payload["chart_input"]
+            brand = payload.get("branding") or {}
             out = _ASSETS_BASE / f"{rid}.pdf"
-            render_western_natal_pdf(
-                data, str(out), branding=(payload.get("branding") or {})
-            )
+            if product == "western_natal_pdf":
+                data = _build_payload(payload)
+                render_western_natal_pdf(data, str(out), branding=brand)
+            elif product == "yearly_forecast_pdf":
+                from ..services.forecast_builders import yearly_payload
+                data = yearly_payload(ci, payload.get("options", {"year": 2025}))
+                render_western_natal_pdf(
+                    data,
+                    str(out),
+                    branding=brand,
+                    template_name="yearly_forecast.html.j2",
+                )
+            elif product == "monthly_horoscope_pdf":
+                from ..services.forecast_builders import monthly_payload
+                data = monthly_payload(ci, payload.get("options", {"year": 2025, "month": 8}))
+                render_western_natal_pdf(
+                    data,
+                    str(out),
+                    branding=brand,
+                    template_name="monthly_horoscope.html.j2",
+                )
+            elif product == "compatibility_pdf":
+                from ..services.compatibility_engine import (
+                    synastry,
+                    midpoint_composite,
+                    aggregate_score,
+                )
+                other = payload["partner_chart_input"]
+                types = ["conjunction", "opposition", "square", "trine", "sextile"]
+                syn = synastry(ci, other, types, 4.0)
+                score = aggregate_score(syn)
+                comp = midpoint_composite(ci, other)
+                data = {"synastry": syn, "score": score, "composite": comp}
+                render_western_natal_pdf(
+                    data,
+                    str(out),
+                    branding=brand,
+                    template_name="compatibility.html.j2",
+                )
+            elif product == "remedies_pdf":
+                from ..services.remedies_engine import compute_remedies
+                data = {"items": compute_remedies(ci, allow_gemstones=True)}
+                render_western_natal_pdf(
+                    data,
+                    str(out),
+                    branding=brand,
+                    template_name="remedies.html.j2",
+                )
+            elif product == "spiritual_mission_pdf":
+                data = {
+                    "themes": [
+                        "Growth via service and learning",
+                        "Letting go of past attachments",
+                    ],
+                    "notes": [],
+                }
+                render_western_natal_pdf(
+                    data,
+                    str(out),
+                    branding=brand,
+                    template_name="spiritual_mission.html.j2",
+                )
+            else:
+                raise ValueError("UNKNOWN_PRODUCT")
             STORE.update(rid, status="done", file_path=str(out))
         except Exception:
             traceback.print_exc()
@@ -166,6 +125,4 @@ def ensure_worker_started() -> None:
 
 
 if __name__ == "__main__":
-    main()
-
-
+    ensure_worker_started()

--- a/api/routers/compatibility.py
+++ b/api/routers/compatibility.py
@@ -1,0 +1,49 @@
+from fastapi import APIRouter, Body
+from ..schemas import CompatibilityComputeRequest, CompatibilityComputeResponse
+from ..services.compatibility_engine import synastry, midpoint_composite, aggregate_score
+
+router = APIRouter(prefix="/v1/compatibility", tags=["compatibility"])
+
+
+@router.post("/compute", response_model=CompatibilityComputeResponse)
+def compute_compat(
+    req: CompatibilityComputeRequest = Body(
+        ...,
+        example={
+            "person_a": {
+                "system": "western",
+                "date": "1990-08-18",
+                "time": "14:32:00",
+                "time_known": True,
+                "place": {"lat": 17.385, "lon": 78.4867, "tz": "Asia/Kolkata"},
+            },
+            "person_b": {
+                "system": "western",
+                "date": "1991-03-07",
+                "time": "09:15:00",
+                "time_known": True,
+                "place": {"lat": 28.6139, "lon": 77.2090, "tz": "Asia/Kolkata"},
+            },
+            "options": {"include_composite": True},
+        },
+    )
+):
+    types = req.options.aspects.get("types", ["conjunction", "opposition", "square", "trine", "sextile"])
+    orb = req.options.aspects.get("orb_deg", 4.0)
+    syn = synastry(req.person_a.model_dump(), req.person_b.model_dump(), types, orb)
+    score = aggregate_score(syn)
+    strengths = [f"{s['p1']} {s['type']} {s['p2']}" for s in syn if s["weight"] > 0][:10]
+    challenges = [f"{s['p1']} {s['type']} {s['p2']}" for s in syn if s["weight"] < 0][:10]
+    comp = (
+        midpoint_composite(req.person_a.model_dump(), req.person_b.model_dump())
+        if req.options.include_composite
+        else None
+    )
+    return CompatibilityComputeResponse(
+        meta={"orb_deg": orb},
+        synastry=syn,
+        score=score,
+        strengths=strengths,
+        challenges=challenges,
+        composite=comp,
+    )

--- a/api/routers/forecasts.py
+++ b/api/routers/forecasts.py
@@ -1,0 +1,58 @@
+from fastapi import APIRouter, Body
+from ..schemas import (
+    YearlyForecastRequest,
+    YearlyForecastResponse,
+    MonthlyForecastRequest,
+    MonthlyForecastResponse,
+)
+from ..services.forecast_builders import yearly_payload, monthly_payload
+
+router = APIRouter(prefix="/v1/forecasts", tags=["forecasts"])
+
+
+@router.post("/yearly", response_model=YearlyForecastResponse)
+def compute_yearly(
+    req: YearlyForecastRequest = Body(
+        ...,
+        example={
+            "chart_input": {
+                "system": "western",
+                "date": "1990-08-18",
+                "time": "14:32:00",
+                "time_known": True,
+                "place": {"lat": 17.385, "lon": 78.4867, "tz": "Asia/Kolkata"},
+            },
+            "options": {"year": 1991},
+        },
+    )
+):
+    data = yearly_payload(req.chart_input.model_dump(), req.options.model_dump())
+    return YearlyForecastResponse(
+        meta={"year": req.options.year},
+        months=data["months"],
+        top_events=data["top_events"],
+    )
+
+
+@router.post("/monthly", response_model=MonthlyForecastResponse)
+def compute_monthly(
+    req: MonthlyForecastRequest = Body(
+        ...,
+        example={
+            "chart_input": {
+                "system": "western",
+                "date": "1990-08-18",
+                "time": "14:32:00",
+                "time_known": True,
+                "place": {"lat": 17.385, "lon": 78.4867, "tz": "Asia/Kolkata"},
+            },
+            "options": {"year": 1990, "month": 9},
+        },
+    )
+):
+    data = monthly_payload(req.chart_input.model_dump(), req.options.model_dump())
+    return MonthlyForecastResponse(
+        meta={"year": req.options.year, "month": req.options.month},
+        events=data["events"],
+        highlights=data["highlights"],
+    )

--- a/api/routers/remedies.py
+++ b/api/routers/remedies.py
@@ -1,0 +1,30 @@
+from fastapi import APIRouter, Body
+from ..schemas import RemediesComputeRequest, RemediesComputeResponse
+from ..services.remedies_engine import compute_remedies
+
+router = APIRouter(prefix="/v1/remedies", tags=["remedies"])
+
+
+@router.post("/compute", response_model=RemediesComputeResponse)
+def compute_remedies_route(
+    req: RemediesComputeRequest = Body(
+        ...,
+        example={
+            "chart_input": {
+                "system": "vedic",
+                "date": "1990-08-18",
+                "time": "14:32:00",
+                "time_known": True,
+                "place": {"lat": 17.385, "lon": 78.4867, "tz": "Asia/Kolkata"},
+            },
+            "options": {"allow_gemstones": True},
+        },
+    )
+):
+    items = compute_remedies(
+        req.chart_input.model_dump(), allow_gemstones=req.options.allow_gemstones
+    )
+    return RemediesComputeResponse(
+        meta={"allow_gemstones": req.options.allow_gemstones},
+        remedies=items,
+    )

--- a/api/schemas/__init__.py
+++ b/api/schemas/__init__.py
@@ -5,3 +5,15 @@ from .transits import TransitsComputeRequest, TransitsComputeResponse
 
 from .reports import ReportCreateRequest, ReportStatus, Branding, Product
 
+from .forecasts import (
+    YearlyForecastRequest,
+    YearlyForecastResponse,
+    MonthlyForecastRequest,
+    MonthlyForecastResponse,
+)
+from .compatibility import (
+    CompatibilityComputeRequest,
+    CompatibilityComputeResponse,
+)
+from .remedies import RemediesComputeRequest, RemediesComputeResponse
+

--- a/api/schemas/compatibility.py
+++ b/api/schemas/compatibility.py
@@ -1,0 +1,41 @@
+from pydantic import BaseModel
+from typing import Optional, List, Dict, Any
+from .charts import ChartInput
+
+
+class CompatibilityOptions(BaseModel):
+    aspects: Dict[str, Any] = {
+        "types": ["conjunction", "opposition", "square", "trine", "sextile"],
+        "orb_deg": 4.0,
+    }
+    include_composite: bool = True
+
+
+class SynAspect(BaseModel):
+    p1: str
+    p2: str
+    type: str
+    orb: float
+    weight: float
+
+
+class CompositePoint(BaseModel):
+    name: str
+    lon: float
+    sign: str
+    house: Optional[int]
+
+
+class CompatibilityComputeRequest(BaseModel):
+    person_a: ChartInput
+    person_b: ChartInput
+    options: CompatibilityOptions = CompatibilityOptions()
+
+
+class CompatibilityComputeResponse(BaseModel):
+    meta: Dict[str, Any]
+    synastry: List[SynAspect]
+    score: float
+    strengths: List[str]
+    challenges: List[str]
+    composite: Optional[List[CompositePoint]] = None

--- a/api/schemas/forecasts.py
+++ b/api/schemas/forecasts.py
@@ -1,0 +1,65 @@
+from pydantic import BaseModel
+from typing import Optional, List, Dict, Any
+from .charts import ChartInput
+
+
+class YearlyOptions(BaseModel):
+    year: int
+    step_days: int = 1
+    include_progressions: bool = True
+    transit_bodies: List[str] = ["Sun", "Mercury", "Venus", "Mars", "Jupiter", "Saturn"]
+    aspects: Dict[str, Any] = {
+        "types": ["conjunction", "opposition", "square", "trine", "sextile"],
+        "orb_deg": 3.0,
+    }
+
+
+class MonthOptions(BaseModel):
+    year: int
+    month: int
+    step_days: int = 1
+    transit_bodies: List[str] = [
+        "Sun",
+        "Mercury",
+        "Venus",
+        "Mars",
+        "Jupiter",
+        "Saturn",
+        "Moon",
+    ]
+    aspects: Dict[str, Any] = {
+        "types": ["conjunction", "square", "trine", "opposition"],
+        "orb_deg": 3.0,
+    }
+
+
+class ForecastEvent(BaseModel):
+    date: str
+    transit_body: str
+    natal_body: str
+    aspect: str
+    orb: float
+    score: float
+    note: Optional[str] = None
+
+
+class YearlyForecastRequest(BaseModel):
+    chart_input: ChartInput
+    options: YearlyOptions
+
+
+class MonthlyForecastRequest(BaseModel):
+    chart_input: ChartInput
+    options: MonthOptions
+
+
+class YearlyForecastResponse(BaseModel):
+    meta: Dict[str, Any]
+    months: Dict[str, List[ForecastEvent]]
+    top_events: List[ForecastEvent]
+
+
+class MonthlyForecastResponse(BaseModel):
+    meta: Dict[str, Any]
+    events: List[ForecastEvent]
+    highlights: List[ForecastEvent]

--- a/api/schemas/remedies.py
+++ b/api/schemas/remedies.py
@@ -1,0 +1,25 @@
+from pydantic import BaseModel
+from typing import List, Optional, Dict, Any
+from .charts import ChartInput
+
+
+class RemediesOptions(BaseModel):
+    allow_gemstones: bool = True
+
+
+class RemedyItem(BaseModel):
+    planet: str
+    issue: str
+    recommendation: str
+    gemstone: Optional[str] = None
+    cautions: List[str] = []
+
+
+class RemediesComputeRequest(BaseModel):
+    chart_input: ChartInput
+    options: RemediesOptions = RemediesOptions()
+
+
+class RemediesComputeResponse(BaseModel):
+    meta: Dict[str, Any]
+    remedies: List[RemedyItem]

--- a/api/schemas/reports.py
+++ b/api/schemas/reports.py
@@ -4,7 +4,14 @@ from typing import Optional, Literal, Dict, Any
 from .charts import ChartInput
 
 # Supported report product identifiers
-Product = Literal["western_natal_pdf"]
+Product = Literal[
+    "western_natal_pdf",
+    "yearly_forecast_pdf",
+    "monthly_horoscope_pdf",
+    "compatibility_pdf",
+    "remedies_pdf",
+    "spiritual_mission_pdf",
+]
 
 
 class Branding(BaseModel):
@@ -19,6 +26,8 @@ class ReportCreateRequest(BaseModel):
 
     product: Product = "western_natal_pdf"
     chart_input: ChartInput
+    partner_chart_input: Optional[ChartInput] = None
+    options: Optional[Dict[str, Any]] = None
     branding: Optional[Branding] = Branding()
     idempotency_key: Optional[str] = None
 

--- a/api/services/compatibility_engine.py
+++ b/api/services/compatibility_engine.py
@@ -1,0 +1,84 @@
+from typing import Dict, Any, List
+from . import ephem, aspects as aspects_svc, houses as houses_svc
+from .constants import sign_name_from_lon
+
+ASPECT_AFFECTION = {
+    "conjunction": 3,
+    "trine": 2,
+    "sextile": 1,
+    "square": -2,
+    "opposition": -2,
+}
+PAIR_WEIGHTS = {
+    ("Sun", "Sun"): 2,
+    ("Sun", "Moon"): 3,
+    ("Moon", "Moon"): 3,
+    ("Venus", "Mars"): 3,
+    ("Venus", "Venus"): 2,
+    ("Mars", "Mars"): 2,
+}
+
+
+def _natal_positions(chart_input: Dict[str, Any]) -> Dict[str, Dict[str, float]]:
+    sidereal = chart_input["system"] == "vedic"
+    ayan = (
+        (chart_input.get("options") or {}).get("ayanamsha", "lahiri") if sidereal else None
+    )
+    jd = ephem.to_jd_utc(chart_input["date"], chart_input["time"], chart_input["place"]["tz"])
+    return ephem.positions_ecliptic(jd, sidereal=sidereal, ayanamsha=ayan)
+
+
+def synastry(person_a: Dict[str, Any], person_b: Dict[str, Any], aspect_types, orb_deg: float) -> List[Dict[str, Any]]:
+    A = _natal_positions(person_a)
+    B = _natal_positions(person_b)
+    res = []
+    for a_name, a_pos in A.items():
+        for b_name, b_pos in B.items():
+            d = aspects_svc._angle_diff(a_pos["lon"], b_pos["lon"])
+            for t, exact in aspects_svc.MAJOR.items():
+                if t not in aspect_types:
+                    continue
+                if abs(d - exact) <= orb_deg:
+                    orb = round(abs(d - exact), 2)
+                    base = ASPECT_AFFECTION.get(t, 0)
+                    pair_boost = PAIR_WEIGHTS.get((a_name, b_name), 1)
+                    weight = round(
+                        base
+                        * pair_boost
+                        * (1.0 - min(orb / max(0.1, orb_deg), 1.0)),
+                        2,
+                    )
+                    res.append(
+                        {
+                            "p1": a_name,
+                            "p2": b_name,
+                            "type": t,
+                            "orb": orb,
+                            "weight": weight,
+                        }
+                    )
+    res.sort(key=lambda x: -x["weight"])
+    return res
+
+
+def midpoint_composite(person_a: Dict[str, Any], person_b: Dict[str, Any]) -> List[Dict[str, Any]]:
+    A = _natal_positions(person_a)
+    B = _natal_positions(person_b)
+    comp = []
+    for name in A.keys():
+        lon = ((A[name]["lon"] + B[name]["lon"]) / 2.0) % 360.0
+        comp.append(
+            {
+                "name": name,
+                "lon": round(lon, 2),
+                "sign": sign_name_from_lon(lon),
+                "house": None,
+            }
+        )
+    return comp
+
+
+def aggregate_score(syn: List[Dict[str, Any]]) -> float:
+    s = sum(x["weight"] for x in syn)
+    s = max(-30.0, min(30.0, s))
+    return round((s + 30.0) / 60.0 * 100.0, 1)

--- a/api/services/dignities.py
+++ b/api/services/dignities.py
@@ -1,0 +1,35 @@
+RULERS = {
+    "Aries": "Mars",
+    "Taurus": "Venus",
+    "Gemini": "Mercury",
+    "Cancer": "Moon",
+    "Leo": "Sun",
+    "Virgo": "Mercury",
+    "Libra": "Venus",
+    "Scorpio": "Mars",
+    "Sagittarius": "Jupiter",
+    "Capricorn": "Saturn",
+    "Aquarius": "Saturn",
+    "Pisces": "Jupiter",
+}
+EXALT = {
+    "Sun": "Aries",
+    "Moon": "Taurus",
+    "Mercury": "Virgo",
+    "Venus": "Pisces",
+    "Mars": "Capricorn",
+    "Jupiter": "Cancer",
+    "Saturn": "Libra",
+}
+DETRIMENT = {v: k for k, v in RULERS.items()}
+FALL = {v: k for k, v in EXALT.items()}
+
+
+def dignity_for(planet: str, sign: str) -> str:
+    if sign == EXALT.get(planet):
+        return "exaltation"
+    if FALL.get(planet) == sign:
+        return "fall"
+    if RULERS.get(sign) == planet:
+        return "domicile"
+    return "neutral"

--- a/api/services/forecast_builders.py
+++ b/api/services/forecast_builders.py
@@ -1,0 +1,36 @@
+from collections import defaultdict
+from typing import Dict, Any
+from .transits_engine import compute_transits
+
+
+def yearly_payload(chart_input: Dict[str, Any], options: Dict[str, Any]) -> Dict[str, Any]:
+    year = options["year"]
+    opts = {
+        "from_date": f"{year}-01-01",
+        "to_date": f"{year}-12-31",
+        "step_days": options.get("step_days", 1),
+        "transit_bodies": options.get("transit_bodies"),
+        "aspects": options.get("aspects"),
+    }
+    events = compute_transits(chart_input, opts)
+    months = defaultdict(list)
+    for e in events:
+        key = e["date"][:7]
+        months[key].append(e)
+    top = sorted(events, key=lambda x: -x["score"])[:20]
+    return {"months": dict(months), "top_events": top}
+
+
+def monthly_payload(chart_input: Dict[str, Any], options: Dict[str, Any]) -> Dict[str, Any]:
+    y, m = options["year"], options["month"]
+    from_d, to_d = f"{y}-{m:02d}-01", f"{y}-{m:02d}-28"
+    opts = {
+        "from_date": from_d,
+        "to_date": to_d,
+        "step_days": options.get("step_days", 1),
+        "transit_bodies": options.get("transit_bodies"),
+        "aspects": options.get("aspects"),
+    }
+    events = compute_transits(chart_input, opts)
+    highlights = sorted(events, key=lambda x: -x["score"])[:10]
+    return {"events": events, "highlights": highlights}

--- a/api/services/progressions.py
+++ b/api/services/progressions.py
@@ -1,0 +1,27 @@
+from datetime import datetime, timedelta, timezone
+from typing import Dict, Any
+from . import ephem
+
+
+def _to_dt(chart_input: Dict[str, Any]) -> datetime:
+    from zoneinfo import ZoneInfo
+
+    dt_local = datetime.fromisoformat(f"{chart_input['date']}T{chart_input['time']}").replace(
+        tzinfo=ZoneInfo(chart_input["place"]["tz"])
+    )
+    return dt_local.astimezone(timezone.utc)
+
+
+def progressed_positions(chart_input: Dict[str, Any], target_year: int) -> Dict[str, Dict[str, float]]:
+    """Compute secondary progressed positions for ``target_year``."""
+
+    dt0 = _to_dt(chart_input)
+    years = target_year - dt0.year
+    dt_prog = dt0 + timedelta(days=years)
+    jd = ephem.to_jd_utc(dt_prog.date().isoformat(), "12:00:00", "UTC")
+    sidereal = chart_input["system"] == "vedic"
+    ayan = (
+        (chart_input.get("options") or {}).get("ayanamsha", "lahiri") if sidereal else None
+    )
+    pos = ephem.positions_ecliptic(jd, sidereal=sidereal, ayanamsha=ayan)
+    return {k: {"lon": v["lon"], "speed_lon": v["speed_lon"]} for k, v in pos.items()}

--- a/api/services/remedies_engine.py
+++ b/api/services/remedies_engine.py
@@ -1,0 +1,69 @@
+from typing import Dict, Any, List
+from . import ephem
+from .constants import sign_name_from_lon
+from .dignities import dignity_for
+
+GEMSTONES = {
+    "Sun": "Ruby",
+    "Moon": "Pearl",
+    "Mars": "Red Coral",
+    "Mercury": "Emerald",
+    "Jupiter": "Yellow Sapphire",
+    "Venus": "Diamond",
+    "Saturn": "Blue Sapphire",
+    "Rahu": "Hessonite",
+    "Ketu": "Cat's Eye",
+}
+
+
+def compute_remedies(chart_input: Dict[str, Any], allow_gemstones: bool = True) -> List[Dict[str, Any]]:
+    jd = ephem.to_jd_utc(chart_input["date"], chart_input["time"], chart_input["place"]["tz"])
+    sidereal = chart_input["system"] == "vedic"
+    ayan = (
+        (chart_input.get("options") or {}).get("ayanamsha", "lahiri") if sidereal else None
+    )
+    pos = ephem.positions_ecliptic(jd, sidereal=sidereal, ayanamsha=ayan)
+
+    out = []
+    for planet in [
+        "Sun",
+        "Moon",
+        "Mars",
+        "Mercury",
+        "Jupiter",
+        "Venus",
+        "Saturn",
+        "TrueNode",
+        "Chiron",
+    ]:
+        if planet not in pos:
+            continue
+        lon = pos[planet]["lon"]
+        sign = sign_name_from_lon(lon)
+        dig = dignity_for(planet, sign)
+        if dig in ("fall", "detriment"):
+            item = {
+                "planet": planet,
+                "issue": f"{planet} in {dig}",
+                "recommendation": "Strengthen {}-related qualities through disciplined practice, donations, and mantra.".format(
+                    planet
+                ),
+                "gemstone": GEMSTONES.get(planet) if allow_gemstones else None,
+                "cautions": [
+                    "Consult a qualified practitioner.",
+                    "Use certified gemstones only.",
+                    "Budget responsibly.",
+                ],
+            }
+            out.append(item)
+    if not out:
+        out.append(
+            {
+                "planet": "Overall",
+                "issue": "No critical weaknesses detected",
+                "recommendation": "Focus on balanced routines (sleep, diet, meditation) and service.",
+                "gemstone": None,
+                "cautions": [],
+            }
+        )
+    return out

--- a/api/templates/reports/compatibility.html.j2
+++ b/api/templates/reports/compatibility.html.j2
@@ -1,0 +1,22 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8"/>
+  <title>Compatibility Report</title>
+  <link rel="stylesheet" href="{{ css_href }}"/>
+</head>
+<body>
+  <header><h1>Compatibility Score: {{ data.score }}</h1></header>
+  <section>
+    <h2>Synastry Aspects</h2>
+    <table>
+      <thead><tr><th>P1</th><th>Aspect</th><th>P2</th><th>Orb</th></tr></thead>
+      <tbody>
+      {% for s in data.synastry %}
+        <tr><td>{{ s.p1 }}</td><td>{{ s.type }}</td><td>{{ s.p2 }}</td><td>{{ s.orb }}</td></tr>
+      {% endfor %}
+      </tbody>
+    </table>
+  </section>
+</body>
+</html>

--- a/api/templates/reports/monthly_horoscope.html.j2
+++ b/api/templates/reports/monthly_horoscope.html.j2
@@ -1,0 +1,19 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8"/>
+  <title>Monthly Horoscope</title>
+  <link rel="stylesheet" href="{{ css_href }}"/>
+</head>
+<body>
+  <header><h1>Monthly Horoscope</h1></header>
+  <section>
+    <h2>Highlights</h2>
+    <ul>
+    {% for e in data.highlights %}
+      <li>{{ e.date }} - {{ e.transit_body }} {{ e.aspect }} {{ e.natal_body }}</li>
+    {% endfor %}
+    </ul>
+  </section>
+</body>
+</html>

--- a/api/templates/reports/remedies.html.j2
+++ b/api/templates/reports/remedies.html.j2
@@ -1,0 +1,16 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8"/>
+  <title>Remedies Report</title>
+  <link rel="stylesheet" href="{{ css_href }}"/>
+</head>
+<body>
+  <header><h1>Recommended Remedies</h1></header>
+  <ul>
+  {% for item in data.items %}
+    <li><strong>{{ item.planet }}</strong>: {{ item.recommendation }}{% if item.gemstone %} (Gemstone: {{ item.gemstone }}){% endif %}</li>
+  {% endfor %}
+  </ul>
+</body>
+</html>

--- a/api/templates/reports/spiritual_mission.html.j2
+++ b/api/templates/reports/spiritual_mission.html.j2
@@ -1,0 +1,16 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8"/>
+  <title>Spiritual Mission</title>
+  <link rel="stylesheet" href="{{ css_href }}"/>
+</head>
+<body>
+  <header><h1>Spiritual Mission Themes</h1></header>
+  <ul>
+  {% for t in data.themes %}
+    <li>{{ t }}</li>
+  {% endfor %}
+  </ul>
+</body>
+</html>

--- a/api/templates/reports/yearly_forecast.html.j2
+++ b/api/templates/reports/yearly_forecast.html.j2
@@ -1,0 +1,19 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8"/>
+  <title>Yearly Forecast</title>
+  <link rel="stylesheet" href="{{ css_href }}"/>
+</head>
+<body>
+  <header><h1>Yearly Forecast</h1></header>
+  <section>
+    <h2>Top Events</h2>
+    <ul>
+    {% for e in data.top_events %}
+      <li>{{ e.date }} - {{ e.transit_body }} {{ e.aspect }} {{ e.natal_body }}</li>
+    {% endfor %}
+    </ul>
+  </section>
+</body>
+</html>

--- a/tests/test_compatibility.py
+++ b/tests/test_compatibility.py
@@ -1,0 +1,39 @@
+from fastapi.testclient import TestClient
+from api.app import app
+
+client = TestClient(app)
+
+
+def ci1():
+    return {
+        "system": "western",
+        "date": "1990-08-18",
+        "time": "14:32:00",
+        "time_known": True,
+        "place": {"lat": 17.385, "lon": 78.4867, "tz": "Asia/Kolkata"},
+    }
+
+
+def ci2():
+    return {
+        "system": "western",
+        "date": "1991-03-07",
+        "time": "09:15:00",
+        "time_known": True,
+        "place": {"lat": 28.6139, "lon": 77.2090, "tz": "Asia/Kolkata"},
+    }
+
+
+def test_compat_api():
+    r = client.post(
+        "/v1/compatibility/compute",
+        json={
+            "person_a": ci1(),
+            "person_b": ci2(),
+            "options": {"include_composite": True},
+        },
+    )
+    assert r.status_code == 200
+    j = r.json()
+    assert "synastry" in j and "score" in j
+    assert isinstance(j["score"], float)

--- a/tests/test_monthly_forecast.py
+++ b/tests/test_monthly_forecast.py
@@ -1,0 +1,24 @@
+from fastapi.testclient import TestClient
+from api.app import app
+
+client = TestClient(app)
+
+
+def _ci():
+    return {
+        "system": "western",
+        "date": "1990-08-18",
+        "time": "14:32:00",
+        "time_known": True,
+        "place": {"lat": 17.385, "lon": 78.4867, "tz": "Asia/Kolkata"},
+    }
+
+
+def test_monthly_forecast_api():
+    r = client.post(
+        "/v1/forecasts/monthly",
+        json={"chart_input": _ci(), "options": {"year": 1990, "month": 9}},
+    )
+    assert r.status_code == 200
+    j = r.json()
+    assert "events" in j and len(j["events"]) >= 3

--- a/tests/test_remedies.py
+++ b/tests/test_remedies.py
@@ -1,0 +1,24 @@
+from fastapi.testclient import TestClient
+from api.app import app
+
+client = TestClient(app)
+
+
+def ci():
+    return {
+        "system": "vedic",
+        "date": "1990-08-18",
+        "time": "14:32:00",
+        "time_known": True,
+        "place": {"lat": 17.385, "lon": 78.4867, "tz": "Asia/Kolkata"},
+    }
+
+
+def test_remedies_api():
+    r = client.post(
+        "/v1/remedies/compute",
+        json={"chart_input": ci(), "options": {"allow_gemstones": True}},
+    )
+    assert r.status_code == 200
+    j = r.json()
+    assert "remedies" in j and isinstance(j["remedies"], list)

--- a/tests/test_reports_products_m4.py
+++ b/tests/test_reports_products_m4.py
@@ -1,0 +1,58 @@
+import time
+import time
+from fastapi.testclient import TestClient
+from api.app import app
+
+client = TestClient(app)
+
+
+def ci():
+    return {
+        "system": "western",
+        "date": "1990-08-18",
+        "time": "14:32:00",
+        "time_known": True,
+        "place": {"lat": 17.385, "lon": 78.4867, "tz": "Asia/Kolkata"},
+    }
+
+
+def wait_pdf(rid):
+    for _ in range(50):
+        j = client.get(f"/v1/reports/{rid}").json()
+        if j["status"] == "done":
+            pdf = client.get(j["download_url"])
+            assert pdf.status_code == 200 and pdf.content[:4] == b"%PDF"
+            return
+        elif j["status"] == "error":
+            assert False, f"job error: {j}"
+        time.sleep(0.1)
+    assert False, "timeout"
+
+
+def test_yearly_pdf_job():
+    r = client.post(
+        "/v1/reports",
+        json={"product": "yearly_forecast_pdf", "chart_input": ci(), "options": {"year": 1991}},
+    )
+    assert r.status_code == 202
+    wait_pdf(r.json()["report_id"])
+
+
+def test_compat_pdf_job():
+    partner = {
+        "system": "western",
+        "date": "1991-03-07",
+        "time": "09:15:00",
+        "time_known": True,
+        "place": {"lat": 28.6139, "lon": 77.2090, "tz": "Asia/Kolkata"},
+    }
+    r = client.post(
+        "/v1/reports",
+        json={
+            "product": "compatibility_pdf",
+            "chart_input": ci(),
+            "partner_chart_input": partner,
+        },
+    )
+    assert r.status_code == 202
+    wait_pdf(r.json()["report_id"])

--- a/tests/test_yearly_forecast.py
+++ b/tests/test_yearly_forecast.py
@@ -1,0 +1,25 @@
+from fastapi.testclient import TestClient
+from api.app import app
+
+client = TestClient(app)
+
+
+def _ci():
+    return {
+        "system": "western",
+        "date": "1990-08-18",
+        "time": "14:32:00",
+        "time_known": True,
+        "place": {"lat": 17.385, "lon": 78.4867, "tz": "Asia/Kolkata"},
+    }
+
+
+def test_yearly_forecast_api():
+    r = client.post(
+        "/v1/forecasts/yearly",
+        json={"chart_input": _ci(), "options": {"year": 1991}},
+    )
+    assert r.status_code == 200, r.text
+    j = r.json()
+    assert "months" in j and "top_events" in j
+    assert any(len(v) > 0 for v in j["months"].values())


### PR DESCRIPTION
## Summary
- add yearly and monthly forecast endpoints with builders and schemas
- implement compatibility and remedies services with PDF templates
- expand report worker and renderer to handle new products

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b479604ca4832ba0e84c7a54b7bcc9