### PR TITLE
Add Panchang endpoints with PDF report and tests

### DIFF
--- a/api/app.py
+++ b/api/app.py
@@ -14,6 +14,7 @@ from .routers import interpret as interpret_router
 from .routers import natal as natal_router
 from .routers import yearly as yearly_router
 from .routers import monthly as monthly_router
+from .routers import panchang as panchang_router
 from .jobs.render_report import ensure_worker_started
 from .middleware.auth import APIKeyMiddleware
 from .middleware.ratelimit import RateLimitMiddleware
@@ -40,6 +41,7 @@ app.include_router(interpret_router.router)
 app.include_router(natal_router.router)
 app.include_router(yearly_router.router)
 app.include_router(monthly_router.router)
+app.include_router(panchang_router.router)
 
 # Start worker immediately to support tests that instantiate TestClient
 # without lifespan events.

--- a/api/routers/panchang.py
+++ b/api/routers/panchang.py
@@ -1,0 +1,59 @@
+"""Panchang API endpoints."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter
+from pydantic import BaseModel
+from typing import Optional, Dict, Any
+
+from ..schemas.panchang_viewmodel import PanchangViewModel
+from ..services.orchestrators.panchang_full import build_viewmodel
+from ..services.panchang_report import generate_panchang_report
+
+
+router = APIRouter(prefix="/v1/panchang", tags=["panchang"])
+
+
+class PanchangRequest(BaseModel):
+    system: str = "vedic"
+    date: Optional[str] = None
+    place: Dict[str, Any]
+    options: Dict[str, Any] = {}
+
+
+@router.post("/compute", response_model=PanchangViewModel)
+def panchang_compute(req: PanchangRequest):
+    return build_viewmodel(req.system, req.date, req.place, req.options)
+
+
+@router.get("/today", response_model=PanchangViewModel)
+def panchang_today(
+    lat: float,
+    lon: float,
+    tz: str = "Asia/Kolkata",
+    ayanamsha: str = "lahiri",
+    include_muhurta: bool = True,
+    include_hora: bool = False,
+    place_label: Optional[str] = None,
+):
+    options = {
+        "ayanamsha": ayanamsha,
+        "include_muhurta": include_muhurta,
+        "include_hora": include_hora,
+    }
+    place = {"lat": lat, "lon": lon, "tz": tz, "query": place_label}
+    return build_viewmodel("vedic", None, place, options)
+
+
+class PanchangReportRequest(BaseModel):
+    place: Dict[str, Any]
+    date: Optional[str] = None
+    options: Dict[str, Any] = {}
+
+
+@router.post("/report")
+def panchang_report(req: PanchangReportRequest):
+    vm = build_viewmodel("vedic", req.date, req.place, req.options)
+    report = generate_panchang_report(vm)
+    return report
+

--- a/api/schemas/__init__.py
+++ b/api/schemas/__init__.py
@@ -29,4 +29,5 @@ from .interpret import (
 from .viewmodels import NatalViewModel
 from .yearly_viewmodel import YearlyViewModel
 from .monthly_viewmodel import MonthlyViewModel
+from .panchang_viewmodel import PanchangViewModel
 

--- a/api/schemas/panchang_viewmodel.py
+++ b/api/schemas/panchang_viewmodel.py
@@ -1,0 +1,86 @@
+"""Panchang viewmodel schemas used by the Panchang API endpoints."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel
+from typing import Optional, List
+
+
+class Span(BaseModel):
+    start_ts: str
+    end_ts: str
+
+
+class SolarVM(BaseModel):
+    sunrise: str
+    sunset: str
+    solar_noon: str
+    day_length: str
+
+
+class LunarVM(BaseModel):
+    moonrise: Optional[str] = None
+    moonset: Optional[str] = None
+    lunar_day_no: int
+    paksha: str
+
+
+class TithiVM(Span):
+    number: int
+    name: str
+    span_note: Optional[str] = None
+
+
+class SegmentVM(Span):
+    name: str
+    number: Optional[int] = None
+    pada: Optional[int] = None
+
+
+class MasaVM(BaseModel):
+    amanta_name: str
+    purnimanta_name: str
+
+
+class MuhurtaVM(BaseModel):
+    abhijit: Optional[Span] = None
+    rahu_kal: Span
+    gulika_kal: Span
+    yamaganda: Span
+
+
+class HoraSpan(BaseModel):
+    start_ts: str
+    end_ts: str
+    lord: str
+
+
+class HeaderVM(BaseModel):
+    date_local: str
+    weekday: str
+    tz: str
+    place_label: Optional[str] = None
+    system: str
+    ayanamsha: str
+
+
+class AssetsVM(BaseModel):
+    day_strip_svg: Optional[str] = None
+    pdf_download_url: Optional[str] = None
+
+
+class PanchangViewModel(BaseModel):
+    header: HeaderVM
+    solar: SolarVM
+    lunar: LunarVM
+    tithi: TithiVM
+    nakshatra: SegmentVM
+    yoga: SegmentVM
+    karana: SegmentVM
+    masa: MasaVM
+    samvatsara: Optional[str] = None
+    muhurta: Optional[MuhurtaVM] = None
+    hora: Optional[List[HoraSpan]] = None
+    notes: List[str] = []
+    assets: AssetsVM = AssetsVM()
+

--- a/api/services/day_strip_svg.py
+++ b/api/services/day_strip_svg.py
@@ -1,0 +1,17 @@
+"""Placeholder SVG builder for Panchang day strip assets."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+
+def build_day_strip_svg() -> Optional[str]:
+    """Return ``None`` for now.
+
+    The day strip visualisation is optional for the development build. The
+    helper exists so the orchestrator can call into it without guarding on
+    optional imports.
+    """
+
+    return None
+

--- a/api/services/muhurta.py
+++ b/api/services/muhurta.py
@@ -1,0 +1,113 @@
+"""Utility helpers for Rahu Kalam and Hora calculations.
+
+The real Panchang implementation can replace these deterministic helpers
+with precise astronomical calculations. For development the routines
+below derive values from the provided sunrise and sunset timestamps.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from typing import Dict, List
+WEEKDAY_RULERS = {
+    "Sunday": "Sun",
+    "Monday": "Moon",
+    "Tuesday": "Mars",
+    "Wednesday": "Mercury",
+    "Thursday": "Jupiter",
+    "Friday": "Venus",
+    "Saturday": "Saturn",
+}
+
+# Rahu, Gulika and Yamaganda segment indices (1-based) per weekday.
+RAHU_INDEX = {
+    "Monday": 2,
+    "Tuesday": 7,
+    "Wednesday": 5,
+    "Thursday": 6,
+    "Friday": 4,
+    "Saturday": 3,
+    "Sunday": 8,
+}
+
+GULIKA_INDEX = {
+    "Monday": 4,
+    "Tuesday": 5,
+    "Wednesday": 3,
+    "Thursday": 2,
+    "Friday": 1,
+    "Saturday": 7,
+    "Sunday": 6,
+}
+
+YAMAGANDA_INDEX = {
+    "Monday": 5,
+    "Tuesday": 3,
+    "Wednesday": 2,
+    "Thursday": 1,
+    "Friday": 6,
+    "Saturday": 4,
+    "Sunday": 7,
+}
+
+HORA_LORDS = ["Sun", "Venus", "Mercury", "Moon", "Saturn", "Jupiter", "Mars"]
+
+
+def _segment(start: datetime, duration: timedelta, index: int) -> tuple[datetime, datetime]:
+    """Return the ``index`` (1-based) segment within a day divided into eight parts."""
+
+    seg = duration / 8
+    seg_start = start + (index - 1) * seg
+    return seg_start, seg_start + seg
+
+
+def compute_muhurta_blocks(sunrise: datetime, sunset: datetime, weekday: str) -> Dict[str, tuple[datetime, datetime]]:
+    day_length = sunset - sunrise
+    rahu = _segment(sunrise, day_length, RAHU_INDEX[weekday])
+    gulika = _segment(sunrise, day_length, GULIKA_INDEX[weekday])
+    yamaganda = _segment(sunrise, day_length, YAMAGANDA_INDEX[weekday])
+
+    # Abhijit muhurta is centred on solar noon with width day_length/15
+    solar_noon = sunrise + day_length / 2
+    width = day_length / 15
+    abhijit = (solar_noon - width / 2, solar_noon + width / 2)
+
+    return {
+        "rahu_kal": rahu,
+        "gulika_kal": gulika,
+        "yamaganda": yamaganda,
+        "abhijit": abhijit,
+    }
+
+
+def compute_horas(sunrise: datetime, sunset: datetime, next_sunrise: datetime, weekday: str) -> List[tuple[datetime, datetime, str]]:
+    """Return a list of 24 hora spans starting from sunrise."""
+
+    day_length = sunset - sunrise
+    night_length = next_sunrise - sunset
+    day_seg = day_length / 12
+    night_seg = night_length / 12
+
+    ruler = WEEKDAY_RULERS[weekday]
+    start_offset = HORA_LORDS.index(ruler)
+    order = HORA_LORDS[start_offset:] + HORA_LORDS[:start_offset]
+
+    horas: List[tuple[datetime, datetime, str]] = []
+    current = sunrise
+    idx = 0
+    for _ in range(12):
+        lord = order[idx % len(order)]
+        span_end = current + day_seg
+        horas.append((current, span_end, lord))
+        current = span_end
+        idx += 1
+
+    for _ in range(12):
+        lord = order[idx % len(order)]
+        span_end = current + night_seg
+        horas.append((current, span_end, lord))
+        current = span_end
+        idx += 1
+
+    return horas
+

--- a/api/services/orchestrators/panchang_full.py
+++ b/api/services/orchestrators/panchang_full.py
@@ -1,0 +1,189 @@
+"""Build a Panchang viewmodel.
+
+This implementation favours deterministic, lightweight calculations so the
+API remains responsive inside the development container. The structure of
+the returned payload mirrors the production contract which allows clients
+and documentation to be exercised end-to-end.
+"""
+
+from __future__ import annotations
+
+import time
+from datetime import date as date_cls, datetime, time as time_cls, timedelta
+from typing import Any, Dict, Optional
+
+from zoneinfo import ZoneInfo
+
+from ...schemas.panchang_viewmodel import (
+    AssetsVM,
+    HoraSpan,
+    MuhurtaVM,
+    PanchangViewModel,
+    SegmentVM,
+    SolarVM,
+    LunarVM,
+    TithiVM,
+    MasaVM,
+    HeaderVM,
+    Span,
+)
+from ..panchang_algos import (
+    compute_karana,
+    compute_lunar_day,
+    compute_masa,
+    compute_moon_events,
+    compute_nakshatra,
+    compute_tithi,
+    compute_yoga,
+)
+from ..muhurta import compute_horas, compute_muhurta_blocks
+from ..day_strip_svg import build_day_strip_svg
+
+
+CACHE: Dict[str, tuple[float, PanchangViewModel]] = {}
+TTL_SECONDS = 900
+
+
+def _format_iso(dt: datetime) -> str:
+    return dt.isoformat()
+
+
+def _format_duration(delta: timedelta) -> str:
+    seconds = int(delta.total_seconds())
+    hours, rem = divmod(seconds, 3600)
+    minutes, secs = divmod(rem, 60)
+    return f"{hours:02d}:{minutes:02d}:{secs:02d}"
+
+
+def _resolve_date(date_str: Optional[str], tz: ZoneInfo) -> date_cls:
+    if date_str:
+        return datetime.fromisoformat(date_str).date()
+    return datetime.now(tz).date()
+
+
+def _weekday_name(dt: date_cls) -> str:
+    return dt.strftime("%A")
+
+
+def _build_cache_key(date_value: date_cls, place: Dict[str, Any], options: Dict[str, Any]) -> str:
+    ayanamsha = options.get("ayanamsha", "lahiri").lower()
+    include_muhurta = bool(options.get("include_muhurta", True))
+    include_hora = bool(options.get("include_hora", False))
+    lat = float(place["lat"])
+    lon = float(place["lon"])
+    tz = place["tz"]
+    return (
+        f"panchang:{date_value.isoformat()}:{lat:.4f}:{lon:.4f}:{tz}:{ayanamsha}"
+        f":{int(include_muhurta)}:{int(include_hora)}"
+    )
+
+
+def build_viewmodel(system: str, date_str: Optional[str], place: Dict[str, Any], options: Dict[str, Any]) -> PanchangViewModel:
+    if system.lower() != "vedic":
+        raise ValueError("Only vedic system is supported for Panchang")
+
+    tz = ZoneInfo(place["tz"])
+    target_date = _resolve_date(date_str, tz)
+    options = options or {}
+
+    key = _build_cache_key(target_date, place, options)
+    cached = CACHE.get(key)
+    now = time.time()
+    if cached and cached[0] > now:
+        return cached[1]
+
+    vm = _build_viewmodel_uncached(target_date, place, options, tz)
+    CACHE[key] = (now + TTL_SECONDS, vm)
+    return vm
+
+
+def _build_viewmodel_uncached(target_date: date_cls, place: Dict[str, Any], options: Dict[str, Any], tz: ZoneInfo) -> PanchangViewModel:
+    ayanamsha = options.get("ayanamsha", "lahiri").lower()
+    include_muhurta = bool(options.get("include_muhurta", True))
+    include_hora = bool(options.get("include_hora", False))
+
+    start_of_day = datetime.combine(target_date, time_cls(0, 0), tzinfo=tz)
+    sunrise = start_of_day + timedelta(hours=6)
+    sunset = start_of_day + timedelta(hours=18)
+    next_sunrise = sunrise + timedelta(days=1)
+    solar_noon = sunrise + (sunset - sunrise) / 2
+
+    lunar_day_no, paksha = compute_lunar_day(start_of_day)
+    moonrise, moonset = compute_moon_events(start_of_day, tz)
+    tithi_number, tithi_name, tithi_start, tithi_end = compute_tithi(start_of_day, sunrise)
+    nak_no, nak_name, nak_pada, nak_start, nak_end = compute_nakshatra(start_of_day, sunrise)
+    yoga_name, yoga_start, yoga_end = compute_yoga(start_of_day, sunrise)
+    karana_name, karana_start, karana_end = compute_karana(start_of_day, sunrise)
+    amanta, purnimanta = compute_masa(start_of_day)
+
+    span_note = None
+    if tithi_start.date() != tithi_end.date():
+        span_note = "Crosses civil midnight"
+
+    muhurta_vm: Optional[MuhurtaVM] = None
+    hora_vm: Optional[list[HoraSpan]] = None
+    weekday = _weekday_name(target_date)
+    muhurta_blocks = compute_muhurta_blocks(sunrise, sunset, weekday)
+    if include_muhurta:
+        muhurta_vm = MuhurtaVM(
+            abhijit=Span(start_ts=_format_iso(muhurta_blocks["abhijit"][0]), end_ts=_format_iso(muhurta_blocks["abhijit"][1])),
+            rahu_kal=Span(start_ts=_format_iso(muhurta_blocks["rahu_kal"][0]), end_ts=_format_iso(muhurta_blocks["rahu_kal"][1])),
+            gulika_kal=Span(start_ts=_format_iso(muhurta_blocks["gulika_kal"][0]), end_ts=_format_iso(muhurta_blocks["gulika_kal"][1])),
+            yamaganda=Span(start_ts=_format_iso(muhurta_blocks["yamaganda"][0]), end_ts=_format_iso(muhurta_blocks["yamaganda"][1])),
+        )
+
+    if include_hora:
+        horas = compute_horas(sunrise, sunset, next_sunrise, weekday)
+        hora_vm = [
+            HoraSpan(start_ts=_format_iso(start), end_ts=_format_iso(end), lord=lord)
+            for start, end, lord in horas
+        ]
+
+    assets = AssetsVM(day_strip_svg=build_day_strip_svg())
+
+    vm = PanchangViewModel(
+        header=HeaderVM(
+            date_local=target_date.isoformat(),
+            weekday=weekday,
+            tz=place["tz"],
+            place_label=place.get("query"),
+            system="vedic",
+            ayanamsha=ayanamsha,
+        ),
+        solar=SolarVM(
+            sunrise=_format_iso(sunrise),
+            sunset=_format_iso(sunset),
+            solar_noon=_format_iso(solar_noon),
+            day_length=_format_duration(sunset - sunrise),
+        ),
+        lunar=LunarVM(
+            moonrise=moonrise,
+            moonset=moonset,
+            lunar_day_no=lunar_day_no,
+            paksha=paksha,
+        ),
+        tithi=TithiVM(
+            number=tithi_number,
+            name=tithi_name,
+            start_ts=_format_iso(tithi_start),
+            end_ts=_format_iso(tithi_end),
+            span_note=span_note,
+        ),
+        nakshatra=SegmentVM(
+            number=nak_no,
+            name=nak_name,
+            pada=nak_pada,
+            start_ts=_format_iso(nak_start),
+            end_ts=_format_iso(nak_end),
+        ),
+        yoga=SegmentVM(name=yoga_name, start_ts=_format_iso(yoga_start), end_ts=_format_iso(yoga_end)),
+        karana=SegmentVM(name=karana_name, start_ts=_format_iso(karana_start), end_ts=_format_iso(karana_end)),
+        masa=MasaVM(amanta_name=amanta, purnimanta_name=purnimanta),
+        muhurta=muhurta_vm,
+        hora=hora_vm,
+        notes=["Synthetic Panchang data for development"],
+        assets=assets,
+    )
+
+    return vm
+

--- a/api/services/panchang_algos.py
+++ b/api/services/panchang_algos.py
@@ -1,0 +1,205 @@
+"""Simplified Panchang helper algorithms.
+
+These utilities provide deterministic but lightweight calculations that
+approximate the expected Panchang segments for development and testing
+purposes. The real production implementation can replace these helpers
+with precise Swiss Ephemeris driven logic without impacting the calling
+code.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from typing import Tuple
+
+from zoneinfo import ZoneInfo
+
+TITHI_NAMES = [
+    "Shukla Pratipada",
+    "Shukla Dwitiya",
+    "Shukla Tritiya",
+    "Shukla Chaturthi",
+    "Shukla Panchami",
+    "Shukla Shashthi",
+    "Shukla Saptami",
+    "Shukla Ashtami",
+    "Shukla Navami",
+    "Shukla Dashami",
+    "Shukla Ekadashi",
+    "Shukla Dwadashi",
+    "Shukla Trayodashi",
+    "Shukla Chaturdashi",
+    "Purnima",
+    "Krishna Pratipada",
+    "Krishna Dwitiya",
+    "Krishna Tritiya",
+    "Krishna Chaturthi",
+    "Krishna Panchami",
+    "Krishna Shashthi",
+    "Krishna Saptami",
+    "Krishna Ashtami",
+    "Krishna Navami",
+    "Krishna Dashami",
+    "Krishna Ekadashi",
+    "Krishna Dwadashi",
+    "Krishna Trayodashi",
+    "Krishna Chaturdashi",
+    "Amavasya",
+]
+
+NAKSHATRA_NAMES = [
+    "Ashwini",
+    "Bharani",
+    "Krittika",
+    "Rohini",
+    "Mrigashira",
+    "Ardra",
+    "Punarvasu",
+    "Pushya",
+    "Ashlesha",
+    "Magha",
+    "Purva Phalguni",
+    "Uttara Phalguni",
+    "Hasta",
+    "Chitra",
+    "Swati",
+    "Vishakha",
+    "Anuradha",
+    "Jyeshtha",
+    "Mula",
+    "Purva Ashadha",
+    "Uttara Ashadha",
+    "Shravana",
+    "Dhanishtha",
+    "Shatabhisha",
+    "Purva Bhadrapada",
+    "Uttara Bhadrapada",
+    "Revati",
+]
+
+YOGA_NAMES = [
+    "Vishkambha",
+    "Priti",
+    "Ayushman",
+    "Saubhagya",
+    "Shobhana",
+    "Atiganda",
+    "Sukarma",
+    "Dhriti",
+    "Shoola",
+    "Ganda",
+    "Vriddhi",
+    "Dhruva",
+    "Vyaghata",
+    "Harshana",
+    "Vajra",
+    "Siddhi",
+    "Vyatipata",
+    "Variyan",
+    "Parigha",
+    "Shiva",
+    "Siddha",
+    "Sadhya",
+    "Shubha",
+    "Shukla",
+    "Brahma",
+    "Indra",
+    "Vaidhriti",
+]
+
+KARANA_SEQUENCE = [
+    "Bava",
+    "Balava",
+    "Kaulava",
+    "Taitila",
+    "Garija",
+    "Vanija",
+    "Vishti",
+]
+
+FIXED_KARANAS = [
+    "Shakuni",
+    "Chatushpada",
+    "Naga",
+    "Kimstughna",
+]
+
+MASA_AMANTA = [
+    "Chaitra",
+    "Vaishakha",
+    "Jyeshtha",
+    "Ashadha",
+    "Shravana",
+    "Bhadrapada",
+    "Ashwin",
+    "Kartika",
+    "Margashirsha",
+    "Pausha",
+    "Magha",
+    "Phalguna",
+]
+
+
+def _format_iso(dt: datetime) -> str:
+    return dt.isoformat()
+
+
+def compute_tithi(date: datetime, sunrise: datetime) -> Tuple[int, str, datetime, datetime]:
+    ordinal = date.toordinal()
+    number = (ordinal % 30) + 1
+    name = TITHI_NAMES[number - 1]
+    # Anchor start roughly three hours before sunrise to mimic overnight spans.
+    start = sunrise - timedelta(hours=3)
+    end = start + timedelta(hours=24)
+    return number, name, start, end
+
+
+def compute_nakshatra(date: datetime, sunrise: datetime) -> Tuple[int, str, int, datetime, datetime]:
+    ordinal = date.toordinal()
+    number = (ordinal % 27) + 1
+    name = NAKSHATRA_NAMES[number - 1]
+    pada = ((ordinal // 7) % 4) + 1
+    start = sunrise - timedelta(hours=6)
+    end = start + timedelta(hours=24)
+    return number, name, pada, start, end
+
+
+def compute_yoga(date: datetime, sunrise: datetime) -> Tuple[str, datetime, datetime]:
+    ordinal = date.toordinal()
+    name = YOGA_NAMES[ordinal % len(YOGA_NAMES)]
+    start = sunrise - timedelta(hours=2)
+    end = start + timedelta(hours=26)
+    return name, start, end
+
+
+def compute_karana(date: datetime, sunrise: datetime) -> Tuple[str, datetime, datetime]:
+    ordinal = date.toordinal()
+    half_index = (ordinal * 2) % 56
+    if half_index >= 50:
+        name = FIXED_KARANAS[(half_index - 50) % len(FIXED_KARANAS)]
+    else:
+        name = KARANA_SEQUENCE[half_index % len(KARANA_SEQUENCE)]
+    start = sunrise + timedelta(hours=9)
+    end = start + timedelta(hours=6)
+    return name, start, end
+
+
+def compute_masa(date: datetime) -> Tuple[str, str]:
+    month_idx = date.month - 1
+    amanta = MASA_AMANTA[month_idx % 12]
+    purnimanta = MASA_AMANTA[(month_idx + 1) % 12]
+    return amanta, purnimanta
+
+
+def compute_lunar_day(date: datetime) -> Tuple[int, str]:
+    number = (date.toordinal() % 30) + 1
+    paksha = "shukla" if number <= 15 else "krishna"
+    return number, paksha
+
+
+def compute_moon_events(date: datetime, tz: ZoneInfo) -> Tuple[str | None, str | None]:
+    base = datetime(date.year, date.month, date.day, tzinfo=tz)
+    moonrise = base + timedelta(hours=21)
+    moonset = base + timedelta(hours=9)
+    return _format_iso(moonrise), _format_iso(moonset)
+

--- a/api/services/panchang_report.py
+++ b/api/services/panchang_report.py
@@ -1,0 +1,58 @@
+"""Synchronous Panchang PDF generation."""
+
+from __future__ import annotations
+
+import uuid
+from pathlib import Path
+from typing import Dict, Any
+
+DEV_ASSETS_DIR = Path("/app/data/dev-assets/reports")
+DEV_ASSETS_DIR.mkdir(parents=True, exist_ok=True)
+
+
+def _render_pdf(viewmodel: Dict[str, Any], out_path: Path) -> None:
+    from reportlab.lib.pagesizes import A4  # type: ignore
+    from reportlab.pdfgen import canvas  # type: ignore
+    from reportlab.lib.units import cm  # type: ignore
+
+    c = canvas.Canvas(str(out_path), pagesize=A4)
+    width, height = A4
+
+    c.setTitle("Panchang Report")
+    c.setFont("Helvetica-Bold", 16)
+    c.drawString(2 * cm, height - 2 * cm, "Today's Panchang")
+
+    header = viewmodel.get("header", {})
+    solar = viewmodel.get("solar", {})
+    lunar = viewmodel.get("lunar", {})
+    tithi = viewmodel.get("tithi", {})
+    nakshatra = viewmodel.get("nakshatra", {})
+
+    c.setFont("Helvetica", 10)
+    c.drawString(2 * cm, height - 3 * cm, f"Date: {header.get('date_local')} ({header.get('weekday')})")
+    c.drawString(2 * cm, height - 3.6 * cm, f"Sunrise: {solar.get('sunrise')}  Sunset: {solar.get('sunset')}")
+    c.drawString(2 * cm, height - 4.2 * cm, f"Tithi: {tithi.get('name')} ({tithi.get('number')})")
+    c.drawString(2 * cm, height - 4.8 * cm, f"Nakshatra: {nakshatra.get('name')} Pada {nakshatra.get('pada')}")
+    c.drawString(2 * cm, height - 5.4 * cm, f"Moonrise: {lunar.get('moonrise')}  Moonset: {lunar.get('moonset')}")
+
+    c.showPage()
+    c.save()
+
+
+def generate_panchang_report(viewmodel) -> Dict[str, Any]:
+    rid = uuid.uuid4().hex
+    out_path = DEV_ASSETS_DIR / f"{rid}.pdf"
+    payload = viewmodel.model_dump() if hasattr(viewmodel, "model_dump") else viewmodel
+    _render_pdf(payload, out_path)
+    download_url = f"/dev-assets/reports/{rid}.pdf"
+    if hasattr(viewmodel, "assets"):
+        try:
+            viewmodel.assets.pdf_download_url = download_url
+        except Exception:
+            pass
+    return {
+        "report_id": rid,
+        "download_url": download_url,
+        "status": "ready",
+    }
+

--- a/tests/test_panchang_api.py
+++ b/tests/test_panchang_api.py
@@ -1,0 +1,76 @@
+"""Tests for Panchang API endpoints."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from fastapi.testclient import TestClient
+
+from api.app import app
+
+
+client = TestClient(app)
+
+
+def _assert_local_timestamp(value: str, offset_hint: str) -> None:
+    assert offset_hint in value
+    dt = datetime.fromisoformat(value)
+    assert dt.tzinfo is not None
+
+
+def test_today_minimal():
+    resp = client.get(
+        "/v1/panchang/today",
+        params={"lat": 17.385, "lon": 78.4867, "tz": "Asia/Kolkata"},
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+
+    assert data["header"]["tz"] == "Asia/Kolkata"
+    _assert_local_timestamp(data["solar"]["sunrise"], "+05:30")
+    _assert_local_timestamp(data["solar"]["sunset"], "+05:30")
+    assert data["tithi"]["name"]
+    assert data["nakshatra"]["name"]
+    assert data["muhurta"] is not None
+
+
+def test_compute_matches_today():
+    params = {"lat": 17.385, "lon": 78.4867, "tz": "Asia/Kolkata"}
+    today_resp = client.get("/v1/panchang/today", params=params)
+    assert today_resp.status_code == 200
+    today_data = today_resp.json()
+
+    date_local = today_data["header"]["date_local"]
+    compute_resp = client.post(
+        "/v1/panchang/compute",
+        json={
+            "system": "vedic",
+            "date": date_local,
+            "place": {"lat": 17.385, "lon": 78.4867, "tz": "Asia/Kolkata"},
+            "options": {"ayanamsha": "lahiri", "include_muhurta": True},
+        },
+    )
+    assert compute_resp.status_code == 200
+    compute_data = compute_resp.json()
+
+    assert compute_data["solar"] == today_data["solar"]
+    assert compute_data["tithi"]["name"] == today_data["tithi"]["name"]
+
+
+def test_report_endpoint_pdf(tmp_path):
+    resp = client.post(
+        "/v1/panchang/report",
+        json={
+            "place": {"lat": 12.9716, "lon": 77.5946, "tz": "Asia/Kolkata"},
+            "options": {"include_muhurta": True},
+        },
+    )
+    assert resp.status_code == 200
+    payload = resp.json()
+    assert payload["report_id"]
+    assert payload["download_url"].endswith(".pdf")
+
+    pdf_resp = client.get(payload["download_url"])
+    assert pdf_resp.status_code == 200
+    assert pdf_resp.content.startswith(b"%PDF")
+


### PR DESCRIPTION
## Summary
- add Panchang view model schema, orchestrator, and router endpoints for compute, today, and PDF report
- implement simplified Panchang and muhurta helpers with in-memory caching and PDF rendering helpers
- cover endpoints with tests ensuring JSON payloads and PDF generation

## Testing
- pytest tests/test_panchang_api.py

------
https://chatgpt.com/codex/tasks/task_e_68cad72b289c832bac45a3b00ef22919