### PR TITLE
Improve Panchang tithi accuracy

### DIFF
--- a/api/services/orchestrators/panchang_full.py
+++ b/api/services/orchestrators/panchang_full.py
@@ -149,7 +149,7 @@ def _build_viewmodel_uncached(target_date: date_cls, place: Dict[str, Any], opti
     next_sunrise = sunrise + timedelta(days=1)
     solar_noon = sunrise + (sunset - sunrise) / 2
 
-    lunar_day_no, paksha = compute_lunar_day(start_of_day)
+    lunar_day_no, paksha = compute_lunar_day(sunrise)
     moonrise, moonset = compute_moon_events(start_of_day, tz)
     tithi_number, _tithi_name, tithi_start, tithi_end = compute_tithi(start_of_day, sunrise)
     nak_no, _nak_name, nak_pada, nak_start, nak_end = compute_nakshatra(start_of_day, sunrise)

--- a/api/services/panchang_algos.py
+++ b/api/services/panchang_algos.py
@@ -9,10 +9,12 @@ code.
 
 from __future__ import annotations
 
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Tuple
 
 from zoneinfo import ZoneInfo
+
+from .ephem import positions_ecliptic
 
 TITHI_NAMES = [
     "Shukla Pratipada",
@@ -144,14 +146,119 @@ def _format_iso(dt: datetime) -> str:
     return dt.isoformat()
 
 
+def _to_jd(moment: datetime) -> float:
+    """Convert a timezone-aware datetime into Julian Day (UT)."""
+    if moment.tzinfo is None:
+        moment = moment.replace(tzinfo=timezone.utc)
+    moment_utc = moment.astimezone(timezone.utc)
+    return moment_utc.timestamp() / 86400.0 + 2440587.5
+
+
+def _moon_sun_diff(moment: datetime) -> float:
+    """Return the longitudinal separation between Moon and Sun in degrees."""
+    jd = _to_jd(moment)
+    positions = positions_ecliptic(jd, sidereal=False)
+    return (positions["Moon"]["lon"] - positions["Sun"]["lon"]) % 360.0
+
+
+def _tithi_state(moment: datetime) -> Tuple[int, float]:
+    """Return the tithi number and raw longitude difference at a moment."""
+    diff = _moon_sun_diff(moment)
+    number = int(diff // 12.0) + 1
+    return number, diff
+
+
+def _unwrap(diff: float, reference: float, forward: bool) -> float:
+    """Unwrap a longitude difference relative to a reference value."""
+    if forward:
+        while diff < reference:
+            diff += 360.0
+    else:
+        while diff > reference:
+            diff -= 360.0
+    return diff
+
+
+def _find_boundary(
+    reference_time: datetime,
+    reference_diff: float,
+    target: float,
+    forward: bool,
+) -> datetime:
+    """Locate the moment when the tithi boundary is crossed."""
+
+    unwrapped_target = target
+    if forward:
+        while unwrapped_target < reference_diff:
+            unwrapped_target += 360.0
+    else:
+        while unwrapped_target > reference_diff:
+            unwrapped_target -= 360.0
+
+    step_hours = 6
+    max_hours = 72
+    direction = 1 if forward else -1
+
+    candidate_time = reference_time
+    candidate_diff = reference_diff
+    hours = step_hours
+    found = False
+    while hours <= max_hours:
+        candidate_time = reference_time + direction * timedelta(hours=hours)
+        candidate_diff = _unwrap(
+            _moon_sun_diff(candidate_time), reference_diff, forward
+        )
+        if forward:
+            if candidate_diff >= unwrapped_target:
+                found = True
+                break
+        else:
+            if candidate_diff <= unwrapped_target:
+                found = True
+                break
+        hours += step_hours
+
+    if not found:
+        candidate_time = reference_time + direction * timedelta(hours=max_hours)
+        candidate_diff = _unwrap(
+            _moon_sun_diff(candidate_time), reference_diff, forward
+        )
+
+    if forward:
+        low_time, low_diff = reference_time, reference_diff
+        high_time, high_diff = candidate_time, candidate_diff
+    else:
+        low_time, low_diff = candidate_time, candidate_diff
+        high_time, high_diff = reference_time, reference_diff
+
+    for _ in range(40):
+        midpoint = low_time + (high_time - low_time) / 2
+        mid_diff = _unwrap(_moon_sun_diff(midpoint), reference_diff, forward)
+        if forward:
+            if mid_diff < unwrapped_target:
+                low_time, low_diff = midpoint, mid_diff
+            else:
+                high_time, high_diff = midpoint, mid_diff
+        else:
+            if mid_diff > unwrapped_target:
+                high_time, high_diff = midpoint, mid_diff
+            else:
+                low_time, low_diff = midpoint, mid_diff
+
+    return high_time
+
+
 def compute_tithi(date: datetime, sunrise: datetime) -> Tuple[int, str, datetime, datetime]:
-    ordinal = date.toordinal()
-    number = (ordinal % 30) + 1
+    number, diff = _tithi_state(sunrise)
     name = TITHI_NAMES[number - 1]
-    # Anchor start roughly three hours before sunrise to mimic overnight spans.
-    start = sunrise - timedelta(hours=3)
-    end = start + timedelta(hours=24)
-    return number, name, start, end
+
+    start_target = (number - 1) * 12.0
+    end_target = number * 12.0
+
+    start_time = _find_boundary(sunrise, diff, start_target, forward=False)
+    end_time = _find_boundary(sunrise, diff, end_target, forward=True)
+
+    return number, name, start_time, end_time
 
 
 def compute_nakshatra(date: datetime, sunrise: datetime) -> Tuple[int, str, int, datetime, datetime]:
@@ -195,8 +302,8 @@ def compute_masa(date: datetime) -> Tuple[int, str, int, str]:
     return month_idx % 12, amanta, (month_idx + 1) % 12, purnimanta
 
 
-def compute_lunar_day(date: datetime) -> Tuple[int, str]:
-    number = (date.toordinal() % 30) + 1
+def compute_lunar_day(moment: datetime) -> Tuple[int, str]:
+    number, _ = _tithi_state(moment)
     paksha = "shukla" if number <= 15 else "krishna"
     return number, paksha
 


### PR DESCRIPTION
## Summary
- compute Panchang tithis using Swiss ephemeris sun/moon longitudes
- derive lunar day and paksha from the same tithi state at sunrise
- keep orchestrator logic aligned with the updated lunar-day helper

## Testing
- `pytest tests/test_panchang_api.py tests/test_panchang_i18n.py`


------
https://chatgpt.com/codex/tasks/task_e_68cae5968038832ba0e51a1f7a76f40b