### PR TITLE
Handle Panchang place defaults

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -52,3 +52,9 @@ NATAL_USE_HTTP=false
 # --- OpenAI ---
 OPENAI_API_KEY=your_openai_api_key
 OPENAI_ORG_ID=your_openai_org_id
+
+# Default place fallbacks for Panchang API
+DEFAULT_PLACE_LAT=28.6139
+DEFAULT_PLACE_LON=77.2090
+DEFAULT_PLACE_TZ=Asia/Kolkata
+DEFAULT_PLACE_LABEL=New Delhi, India

--- a/api/schemas/panchang_viewmodel.py
+++ b/api/schemas/panchang_viewmodel.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from pydantic import BaseModel, Field
-from typing import Optional, List, Dict
+from typing import Any, Optional, List, Dict
 
 
 class Span(BaseModel):
@@ -66,6 +66,7 @@ class HeaderVM(BaseModel):
     system: str
     ayanamsha: str
     locale: LocaleVM
+    meta: Optional[Dict[str, Any]] = None
 
 
 class MasaVM(BaseModel):

--- a/api/services/util/__init__.py
+++ b/api/services/util/__init__.py
@@ -1,0 +1,3 @@
+"""Utility helpers for service orchestration."""
+
+__all__ = []

--- a/api/services/util/place_defaults.py
+++ b/api/services/util/place_defaults.py
@@ -1,0 +1,89 @@
+"""Helpers for normalising Panchang place inputs."""
+
+import os
+from typing import Any, Dict, Optional, Tuple
+
+try:  # pragma: no cover - optional dependency
+    from timezonefinder import TimezoneFinder
+
+    _TF = TimezoneFinder()
+except Exception:  # pragma: no cover - defensive
+    _TF = None
+
+
+DEF_LAT = float(os.getenv("DEFAULT_PLACE_LAT", "28.6139"))
+DEF_LON = float(os.getenv("DEFAULT_PLACE_LON", "77.2090"))
+DEF_TZ = os.getenv("DEFAULT_PLACE_TZ", "Asia/Kolkata")
+DEF_LBL = os.getenv("DEFAULT_PLACE_LABEL", "New Delhi, India")
+
+
+def clamp_lat_lon(lat: float, lon: float) -> Tuple[float, float]:
+    """Clamp latitude/longitude to safe ranges."""
+
+    lat = max(min(lat, 89.9), -89.9)
+    lon = ((lon + 180.0) % 360.0) - 180.0  # wrap to [-180, 180)
+    return lat, lon
+
+
+def infer_tz(lat: float, lon: float) -> Optional[str]:
+    """Infer timezone name for a coordinate pair."""
+
+    if _TF is None:
+        return None
+    try:
+        return _TF.timezone_at(lng=lon, lat=lat)
+    except Exception:  # pragma: no cover - defensive
+        return None
+
+
+def normalize_place(place: Optional[Dict[str, Any]]) -> Tuple[Dict[str, Any], Dict[str, Any]]:
+    """Normalise place payload and capture metadata flags."""
+
+    flags: Dict[str, Any] = {
+        "place_defaults_used": False,
+        "tz_inferred": False,
+        "default_reason": None,
+    }
+
+    if not place:
+        flags.update({"place_defaults_used": True, "default_reason": "missing_place"})
+        return {"lat": DEF_LAT, "lon": DEF_LON, "tz": DEF_TZ, "query": DEF_LBL}, flags
+
+    lat = place.get("lat")
+    lon = place.get("lon")
+    tz = place.get("tz")
+    lbl = place.get("query") or place.get("label") or None
+    elevation = place.get("elevation")
+
+    if lat is None or lon is None:
+        flags.update({"place_defaults_used": True, "default_reason": "missing_latlon"})
+        eff_lat, eff_lon = DEF_LAT, DEF_LON
+        eff_tz = tz or DEF_TZ
+        eff_lbl = lbl or DEF_LBL
+        eff_place = {
+            "lat": eff_lat,
+            "lon": eff_lon,
+            "tz": eff_tz,
+            "query": eff_lbl,
+        }
+        if elevation is not None:
+            eff_place["elevation"] = elevation
+        return eff_place, flags
+
+    lat, lon = clamp_lat_lon(float(lat), float(lon))
+
+    if not tz:
+        tz_guess = infer_tz(lat, lon)
+        if tz_guess:
+            tz = tz_guess
+            flags["tz_inferred"] = True
+            flags["default_reason"] = "missing_tz"
+        else:
+            tz = DEF_TZ
+            flags.update({"tz_inferred": False, "default_reason": "missing_tz"})
+
+    eff_lbl = lbl or f"{lat:.4f}, {lon:.4f}"
+    eff_place = {"lat": lat, "lon": lon, "tz": tz, "query": eff_lbl}
+    if elevation is not None:
+        eff_place["elevation"] = elevation
+    return eff_place, flags

--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -6,7 +6,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends     libcairo2 l
 WORKDIR /app
 
 # Python deps (minimal to boot; expand later)
-RUN pip install --no-cache-dir fastapi uvicorn[standard] jinja2 weasyprint pyswisseph pydantic==2.* boto3 botocore requests python-dotenv pytest httpx
+RUN pip install --no-cache-dir fastapi uvicorn[standard] jinja2 weasyprint pyswisseph pydantic==2.* boto3 botocore requests python-dotenv pytest httpx timezonefinder
 
 # App code
 COPY api/ /app/api/

--- a/tests/test_panchang_defaults.py
+++ b/tests/test_panchang_defaults.py
@@ -1,0 +1,37 @@
+from fastapi.testclient import TestClient
+
+from api.app import app
+
+
+client = TestClient(app)
+
+
+def test_missing_place_uses_defaults():
+    response = client.post(
+        "/v1/panchang/compute",
+        json={"system": "vedic", "options": {"ayanamsha": "lahiri"}},
+    )
+    assert response.status_code == 200
+    payload = response.json()
+    meta = payload["header"]["meta"]
+    assert meta["place_defaults_used"] is True
+    assert meta["default_reason"] in {"missing_place", "missing_latlon"}
+    assert payload["header"]["tz"]
+
+
+def test_missing_tz_is_inferred():
+    response = client.get("/v1/panchang/today?lat=28.6139&lon=77.2090")
+    assert response.status_code == 200
+    payload = response.json()
+    meta = payload["header"]["meta"]
+    assert meta["tz_inferred"] in (True, False)
+    assert payload["header"]["tz"]
+
+
+def test_only_tz_uses_default_coords():
+    response = client.get("/v1/panchang/today?tz=Asia/Kolkata")
+    assert response.status_code == 200
+    payload = response.json()
+    meta = payload["header"]["meta"]
+    assert meta["place_defaults_used"] is True
+    assert payload["header"]["place_label"]


### PR DESCRIPTION
## Summary
- add a place normalisation helper that applies configured defaults and timezone inference
- wire Panchang orchestrator and router to use the normalised place, expose meta flags, and refresh docs
- document default env vars, include timezonefinder in dev image, and cover fallbacks with tests

## Testing
- pytest tests/test_panchang_defaults.py -q

------
https://chatgpt.com/codex/tasks/task_e_68cd603fafac832bb759a45548910ef2