### PR TITLE
Fix Ritu mapping using solar longitude

### DIFF
--- a/api/routers/panchang.py
+++ b/api/routers/panchang.py
@@ -221,7 +221,7 @@ def panchang_compute(
                                         "amanta_name": "Vaishakha",
                                         "purnimanta_name": "Vaishakha",
                                     },
-                                    "ritu": {"drik": "Grishma", "vedic": "Grishma"},
+                                    "ritu": {"drik": "Sharad", "vedic": "Sharad"},
                                     "ayana": "Uttarayana",
                                     "zodiac": {"sun_sign": "Taurus", "moon_sign": "Leo"},
                                 },

--- a/api/services/ext_ritu_dinmana.py
+++ b/api/services/ext_ritu_dinmana.py
@@ -5,24 +5,40 @@ from __future__ import annotations
 from datetime import datetime
 
 
-RITU_NAMES = [
-    "Vasanta",
-    "Grishma",
-    "Varsha",
-    "Sharad",
-    "Hemanta",
-    "Shishira",
+# Degrees are zodiacal, 0° = Aries 0.
+# Each ritu spans TWO signs (12 signs / 6 ritus).
+RITU_BANDS = [
+    ("Vasanta", 330, 360),  # Pisces
+    ("Vasanta", 0, 30),  # Aries
+    ("Grishma", 30, 60),  # Taurus
+    ("Grishma", 60, 90),  # Gemini
+    ("Varsha", 90, 120),  # Cancer
+    ("Varsha", 120, 150),  # Leo
+    ("Sharad", 150, 180),  # Virgo
+    ("Sharad", 180, 210),  # Libra
+    ("Hemanta", 210, 240),  # Scorpio
+    ("Hemanta", 240, 270),  # Sagittarius
+    ("Shishira", 270, 300),  # Capricorn
+    ("Shishira", 300, 330),  # Aquarius
 ]
 
 
-def ritu_drik(sidereal_sun_long: float) -> str:
-    index = int((sidereal_sun_long % 360.0) // 60.0)
-    return RITU_NAMES[index]
+def _ritu_from_longitude(lambda_deg: float) -> str:
+    L = lambda_deg % 360.0
+    for name, a, b in RITU_BANDS:
+        if a < b and a <= L < b:
+            return name
+        if a > b and (L >= a or L < b):
+            return name
+    return "Vasanta"
 
 
-def ritu_vedic(sidereal_sun_long: float) -> str:
-    index = int((sidereal_sun_long % 360.0) // 60.0)
-    return RITU_NAMES[index]
+def ritu_drik(sun_long_tropical_deg: float) -> str:
+    return _ritu_from_longitude(sun_long_tropical_deg)
+
+
+def ritu_vedic(sun_long_sidereal_deg: float) -> str:
+    return _ritu_from_longitude(sun_long_sidereal_deg)
 
 
 def dinmana_ratrimana(
@@ -32,18 +48,23 @@ def dinmana_ratrimana(
 ) -> tuple[str, str]:
     day_len = sunset_local - sunrise_local
     night_len = next_sunrise_local - sunset_local
-    return (str(day_len).split(".")[0], str(night_len).split(".")[0])
+
+    def _fmt(td):
+        return str(td).split(".")[0]
+
+    return _fmt(day_len), _fmt(night_len)
 
 
 def build_ritu_extended(
     convention: str,
-    sidereal_sun_long: float,
+    sun_long_tropical: float,
+    sun_long_sidereal: float,
     sunrise_local: datetime,
     sunset_local: datetime,
     next_sunrise_local: datetime,
 ) -> dict:
-    drik = ritu_drik(sidereal_sun_long)
-    vedic = ritu_vedic(sidereal_sun_long)
+    drik = ritu_drik(sun_long_tropical)
+    vedic = ritu_vedic(sun_long_sidereal)
     din, rat = dinmana_ratrimana(sunrise_local, sunset_local, next_sunrise_local)
     return {
         "drik_ritu": drik,

--- a/tests/test_ritu_mapping.py
+++ b/tests/test_ritu_mapping.py
@@ -1,0 +1,27 @@
+from fastapi.testclient import TestClient
+
+from api.app import app
+
+
+client = TestClient(app)
+
+
+def test_ritu_is_sharad_on_2025_09_19_ist():
+    response = client.post(
+        "/v1/panchang/compute",
+        json={
+            "system": "vedic",
+            "date": "2025-09-19",
+            "place": {
+                "lat": 28.6139,
+                "lon": 77.2090,
+                "tz": "Asia/Kolkata",
+                "query": "New Delhi",
+            },
+            "options": {"ayanamsha": "lahiri"},
+        },
+    )
+    assert response.status_code == 200, response.text
+    payload = response.json()
+    assert payload["ritu_extended"]["drik_ritu"] == "Sharad"
+    assert payload["ritu_extended"]["vedic_ritu"] == "Sharad"


### PR DESCRIPTION
## Summary
- replace the ritu season mapper with a table-driven lookup that works for both drik and vedic conventions
- feed the mapper with tropical and sidereal Sun longitudes from the ephemeris and pass the sidereal value to muhurta helpers
- add an API example tweak and a regression test ensuring 2025-09-19 resolves to Sharad

## Testing
- pytest tests/test_ritu_mapping.py

------
https://chatgpt.com/codex/tasks/task_e_68d1079a3024832bb1ebda409359d081