### PR TITLE
Add helper to download Swiss Ephemeris data

### DIFF
--- a/DEPLOYMENT_README.md
+++ b/DEPLOYMENT_README.md
@@ -104,7 +104,14 @@ wh-ephemeris/
 
 **Files**: [`infra/terraform`](./infra/terraform) – see the accompanying [README](./infra/terraform/README.md) for step-by-step usage.
 
-**Container image**: Build from [`docker/Dockerfile`](./docker/Dockerfile) and push to your Amazon ECR repository before running Terraform so the stack can launch the service task. Download the Swiss Ephemeris data into `data/ephemeris/` first so the container includes the required astronomical files.
+**Container image**: Build from [`docker/Dockerfile`](./docker/Dockerfile) and push to your Amazon ECR repository before running Terraform so the stack can launch the service task. Download the Swiss Ephemeris data into `data/ephemeris/` first so the container includes the required astronomical files. The repository ships with a helper script that retrieves the recommended files directly from Astro.com:
+
+```bash
+# from the repository root
+./scripts/download_ephemeris.sh
+```
+
+The script requires `curl` and `unzip`. It saves `seas_18.se1`, `semo_18.se1`, `sepl_18.se1`, and `de406.eph` into `data/ephemeris/` if they are not already present. You can pass a custom destination folder as the first argument when needed (for example when running inside CI).
 
 **DNS prerequisites when the main site stays on Vercel**:
 

--- a/data/ephemeris/README.md
+++ b/data/ephemeris/README.md
@@ -7,9 +7,14 @@ Swiss ephemeris files (*.se1, *.eph) are excluded from version control due to th
 
 ## 📥 Setup Instructions
 
-1. **Download Swiss ephemeris files** from https://www.astro.com/swisseph/
-2. **Place files in this directory** (`data/ephemeris/`)
-3. **Restart the stack** to pick up the files:
+1. **Run the helper script** (recommended): make sure `curl` and `unzip` are available on your system, then execute
+   ```bash
+   ./scripts/download_ephemeris.sh
+   ```
+   The script fetches the recommended data set (`seas_18.se1`, `semo_18.se1`, `sepl_18.se1`, and `de406.eph`) directly from Astro.com and stores it in this folder. Pass a custom destination as the first argument to download elsewhere (e.g., inside a CI workspace).
+2. **Or download manually** from https://www.astro.com/swisseph/ if you prefer.
+3. **Place files in this directory** (`data/ephemeris/`)
+4. **Restart the stack** to pick up the files:
    ```bash
    docker compose down -v
    docker compose up --build -d

--- a/scripts/download_ephemeris.sh
+++ b/scripts/download_ephemeris.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Download a curated set of Swiss Ephemeris files into data/ephemeris/ so
+# they are available when building the Docker image.
+
+EPHEMERIS_DIR=${1:-data/ephemeris}
+BASE_URL="https://www.astro.com/ftp/swisseph/ephe"
+
+# shellcheck disable=SC2034 # values are URL suffixes used below
+FILES=(
+  "seas_18.se1"
+  "semo_18.se1"
+  "sepl_18.se1"
+  "de406.eph"
+)
+
+mkdir -p "${EPHEMERIS_DIR}"
+
+for file in "${FILES[@]}"; do
+  target_path="${EPHEMERIS_DIR}/${file}"
+  if [[ -f "${target_path}" ]]; then
+    echo "✔ ${file} already exists — skipping"
+    continue
+  fi
+
+  url="${BASE_URL}/${file}"
+  echo "⬇️  Downloading ${file}"
+  if curl -fL "${url}" -o "${target_path}.download"; then
+    mv "${target_path}.download" "${target_path}"
+    echo "✅ Saved ${file}"
+    continue
+  fi
+
+  # Some mirrors only expose zipped variants. Attempt to download the ZIP and
+  # extract the requested file.
+  zip_url="${BASE_URL}/${file%.*}.zip"
+  echo "   Direct download failed, trying ${zip_url}" >&2
+  tmp_zip="${target_path}.zip"
+  if curl -fL "${zip_url}" -o "${tmp_zip}"; then
+    unzip -p "${tmp_zip}" "${file}" > "${target_path}.download"
+    rm -f "${tmp_zip}"
+    mv "${target_path}.download" "${target_path}"
+    echo "✅ Extracted ${file} from ZIP"
+    continue
+  fi
+
+  echo "❌ Failed to download ${file}. Please download it manually from ${BASE_URL}" >&2
+  exit 1
+done
+
+echo "Swiss Ephemeris files available in ${EPHEMERIS_DIR}"


### PR DESCRIPTION
## Summary
- add a helper script to download the Swiss Ephemeris data files into data/ephemeris
- document how to run the helper script in both the deployment and ephemeris readmes
- note the curl/unzip prerequisites and ability to override the destination path

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e5ea26796c832b8a8a613159805bd9