### PR TITLE
Improve markdown cleanup for yearly PDF text

### DIFF
--- a/api/services/yearly_pdf_enhanced.py
+++ b/api/services/yearly_pdf_enhanced.py
@@ -106,37 +106,42 @@ def _strip_markdown(text: str) -> str:
     
     lines = text.split('\n')
     cleaned_lines = []
-    
+
     for line in lines:
         line = line.strip()
-        
+
         # Skip empty lines
         if not line:
             continue
-        
+
         # Convert markdown headings (###, ####, etc.) to plain text
         # Remove heading markers both at start and anywhere in the line
         line = re.sub(r'^#{1,6}\s*', '', line)  # At start (space optional)
         line = re.sub(r'\s*#{1,6}\s*', ' ', line)  # Anywhere else (spaces optional)
-        
-        # Convert **bold** to plain text (remove **)
+
+        # Convert **bold** or __bold__ to plain text (remove markers)
         line = re.sub(r'\*\*([^*]+)\*\*', r'\1', line)
-        
-        # Convert *italic* to plain text (remove single *)
+        line = re.sub(r'__([^_]+)__', r'\1', line)
+
+        # Convert *italic* or _italic_ to plain text (remove markers)
         line = re.sub(r'\*([^*]+)\*', r'\1', line)
-        
+        line = re.sub(r'_([^_]+)_', r'\1', line)
+
         # Convert numbered lists (1. item, 2. item) to bullets
         line = re.sub(r'^\d+\.\s+', '• ', line)
-        
+
         # Convert markdown bullets (- item or * item) to standard bullets
         line = re.sub(r'^[-*]\s+', '• ', line)
-        
+
+        # Remove any leftover repeated markdown markers like **, ###, or ```
+        line = re.sub(r'(\*{2,}|#{2,}|`{2,})', ' ', line)
+
         # Clean up multiple spaces
         line = re.sub(r'\s+', ' ', line).strip()
-        
+
         if line:
             cleaned_lines.append(line)
-    
+
     # Join with single space instead of newlines for paragraph text
     return ' '.join(cleaned_lines)
 

--- a/tests/test_yearly_pdf_enhanced.py
+++ b/tests/test_yearly_pdf_enhanced.py
@@ -7,6 +7,7 @@ pytest.importorskip("reportlab")
 from api.services.yearly_pdf_enhanced import (
     ContentValidator,
     _format_day_callouts,
+    _strip_markdown,
     render_enhanced_yearly_pdf,
 )
 
@@ -22,6 +23,17 @@ def test_content_validator_blocks_wrong_year():
         assert "wrong year" in str(exc)
     else:
         raise AssertionError("Expected ValueError for wrong year reference")
+
+
+def test_strip_markdown_removes_headings_and_bold_markers():
+    raw = (
+        "Eclipses & Lunations 2026-02-17 — eclipse: ### Short Guide to Eclipses and Lunations for 2026 "
+        "#### Solar Eclipse (Partial) - February 17, 2026 - **Theme**: Potent Reset Energy"
+    )
+    cleaned = _strip_markdown(raw)
+    assert "#" not in cleaned
+    assert "*" not in cleaned
+    assert "Short Guide to Eclipses and Lunations for 2026" in cleaned
 
 
 def test_content_validator_strips_technical_notation():


### PR DESCRIPTION
## Summary
- broaden markdown stripping to remove bold/italic markers, headings, and other artifacts before rendering yearly PDFs
- add regression coverage for cleaning eclipse narratives so PDF output no longer shows raw markdown symbols

## Testing
- pytest tests/test_yearly_pdf_enhanced.py -k strip_markdown --maxfail=1


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691e0a4336ec832bbbecff82427f37c4)